### PR TITLE
Added random coherence time support in Memory class

### DIFF
--- a/src/components/memory.py
+++ b/src/components/memory.py
@@ -297,8 +297,12 @@ class Memory(Entity):
 class MemoryWithRandomCoherenceTime(Memory):
     """Individual single-atom memory.
 
-    This class models a single-atom memory, where the quantum state is stored as the spin of a single ion.
-    This class will replace the older implementation once completed.
+    This class inherits Memory class and provides possibility to use stochastic model of
+    coherence time. This means that loss of entanglement of the memory with a photon occurs
+    at random time given by truncated normal distribution with average value set by
+    'coherence_time' input parameter and with standard deviation set by 'coherence_time_stdev'
+    input parameter. If coherence_time_stdev <= 0.0 is passed, the class behaves exactly as
+    original Memory class.
 
     Attributes:
         name (str): label for memory instance.

--- a/src/components/memory.py
+++ b/src/components/memory.py
@@ -94,7 +94,6 @@ class MemoryArray(Entity):
     def set_node(self, node: "QuantumRouter") -> None:
         self.owner = node
 
-
 class Memory(Entity):
     """Individual single-atom memory.
 
@@ -108,7 +107,6 @@ class Memory(Entity):
         frequency (float): maximum frequency at which memory can be excited.
         efficiency (float): probability of emitting a photon when excited.
         coherence_time (float): average usable lifetime of memory (in seconds).
-                                or ( time_average(float), time_stdev(float) ) tuple
         wavelength (float): wavelength (in nm) of emitted photons.
         qstate (QuantumState): quantum state of memory.
         entangled_memory (Dict[str, Any]): tracks entanglement state of memory.
@@ -118,7 +116,7 @@ class Memory(Entity):
     _meas_circuit.measure(0)
 
     def __init__(self, name: str, timeline: "Timeline", fidelity: float, frequency: float,
-                 efficiency: float, coherence_time: Any, wavelength: int):
+                 efficiency: float, coherence_time: int, wavelength: int):
         """Constructor for the Memory class.
 
         Args:
@@ -127,8 +125,7 @@ class Memory(Entity):
             fidelity (float): fidelity of memory.
             frequency (float): maximum frequency of excitation for memory.
             efficiency (float): efficiency of memories.
-            coherence_time (float): average time (in s) that memory state is valid
-                                    or ( time_average(float), time_stdev(float) ) tuple
+            coherence_time (float): average time (in s) that memory state is valid.
             wavelength (int): wavelength (in nm) of photons emitted by memories.
             qstate_key (int): key for associated quantum state in timeline's quantum manager.
         """
@@ -141,23 +138,7 @@ class Memory(Entity):
         self.raw_fidelity = fidelity
         self.frequency = frequency
         self.efficiency = efficiency
-        # coherence time in seconds
-        if not type( coherence_time ) is tuple:
-            self.coherence_time = coherence_time
-            self.random_coherence_time = False
-        else:
-            self.coherence_time = coherence_time[0]
-            self.coherence_time_stdev = coherence_time[1]
-            self.random_coherence_time = ( self.coherence_time_stdev > 0.0 and
-                                          self.coherence_time > 0.0 )
-            
-        if self.random_coherence_time:
-            self.coherence_time_distribution = lambda: stats.truncnorm.rvs(
-                -0.95 * self.coherence_time / self.coherence_time_stdev,
-                19.0 * self.coherence_time / self.coherence_time_stdev,
-                self.coherence_time,
-                self.coherence_time_stdev )
-        
+        self.coherence_time = coherence_time  # coherence time in seconds
         self.wavelength = wavelength
         self.qstate_key = timeline.quantum_manager.new()
 
@@ -276,13 +257,8 @@ class Memory(Entity):
     def _schedule_expiration(self) -> None:
         if self.expiration_event is not None:
             self.timeline.remove_event(self.expiration_event)
-            
-        if not self.random_coherence_time:
-            coherence_period = self.coherence_time
-        else:
-            coherence_period = self.coherence_time_distribution()
 
-        decay_time = self.timeline.now() + int(coherence_period * 1e12)
+        decay_time = self.timeline.now() + int(self.coherence_time * 1e12)
         process = Process(self, "expire", [])
         event = Event(decay_time, process)
         self.timeline.schedule(event)
@@ -317,4 +293,70 @@ class Memory(Entity):
     def detach(self, observer: 'EntanglementProtocol'):
         if observer in self._observers:
             self._observers.remove(observer)
+
+class MemoryWithRandomCoherenceTime(Memory):
+    """Individual single-atom memory.
+
+    This class models a single-atom memory, where the quantum state is stored as the spin of a single ion.
+    This class will replace the older implementation once completed.
+
+    Attributes:
+        name (str): label for memory instance.
+        timeline (Timeline): timeline for simulation.
+        fidelity (float): (current) fidelity of memory.
+        frequency (float): maximum frequency at which memory can be excited.
+        efficiency (float): probability of emitting a photon when excited.
+        coherence_time (float): average usable lifetime of memory (in seconds).
+        coherence_time_stdev (float): standard deviation of coherence time
+        wavelength (float): wavelength (in nm) of emitted photons.
+        qstate (QuantumState): quantum state of memory.
+        entangled_memory (Dict[str, Any]): tracks entanglement state of memory.
+    """
+
+    def __init__(self, name: str, timeline: "Timeline", fidelity: float, frequency: float,
+                 efficiency: float, coherence_time: float, coherence_time_stdev: float, wavelength: int):
+        """Constructor for the Memory class.
+
+        Args:
+            name (str): name of the memory instance.
+            timeline (Timeline): simulation timeline.
+            fidelity (float): fidelity of memory.
+            frequency (float): maximum frequency of excitation for memory.
+            efficiency (float): efficiency of memories.
+            coherence_time (float): average time (in s) that memory state is valid
+            coherence_time_stdev (float): standard deviation of coherence time
+            wavelength (int): wavelength (in nm) of photons emitted by memories.
+            qstate_key (int): key for associated quantum state in timeline's quantum manager.
+        """
+
+        super(MemoryWithRandomCoherenceTime, self).__init__(name, timeline, fidelity, frequency, 
+                         efficiency, coherence_time, wavelength)
+        
+        # coherence time standard deviation in seconds
+        self.coherence_time_stdev = coherence_time_stdev
+        self.random_coherence_time = ( coherence_time_stdev > 0.0 and
+                                      self.coherence_time > 0.0 )
+        
+    def coherence_time_distribution(self) -> None:
+        return stats.truncnorm.rvs(
+            -0.95 * self.coherence_time / self.coherence_time_stdev,
+            19.0 * self.coherence_time / self.coherence_time_stdev,
+            self.coherence_time,
+            self.coherence_time_stdev )        
+
+    def _schedule_expiration(self) -> None:
+        if self.expiration_event is not None:
+            self.timeline.remove_event(self.expiration_event)
+            
+        coherence_period = ( self.coherence_time_distribution() 
+                            if self.random_coherence_time else 
+                            self.coherence_time )
+
+        decay_time = self.timeline.now() + int(coherence_period * 1e12)
+        process = Process(self, "expire", [])
+        event = Event(decay_time, process)
+        self.timeline.schedule(event)
+
+        self.expiration_event = event
+
 

--- a/src/components/memory.py
+++ b/src/components/memory.py
@@ -94,7 +94,6 @@ class MemoryArray(Entity):
     def set_node(self, node: "QuantumRouter") -> None:
         self.owner = node
 
-
 class Memory(Entity):
     """Individual single-atom memory.
 
@@ -108,7 +107,6 @@ class Memory(Entity):
         frequency (float): maximum frequency at which memory can be excited.
         efficiency (float): probability of emitting a photon when excited.
         coherence_time (float): average usable lifetime of memory (in seconds).
-                                or ( time_average(float), time_stdev(float) ) tuple
         wavelength (float): wavelength (in nm) of emitted photons.
         qstate (QuantumState): quantum state of memory.
         entangled_memory (Dict[str, Any]): tracks entanglement state of memory.
@@ -118,7 +116,7 @@ class Memory(Entity):
     _meas_circuit.measure(0)
 
     def __init__(self, name: str, timeline: "Timeline", fidelity: float, frequency: float,
-                 efficiency: float, coherence_time: Any, wavelength: int):
+                 efficiency: float, coherence_time: int, wavelength: int):
         """Constructor for the Memory class.
 
         Args:
@@ -127,8 +125,7 @@ class Memory(Entity):
             fidelity (float): fidelity of memory.
             frequency (float): maximum frequency of excitation for memory.
             efficiency (float): efficiency of memories.
-            coherence_time (float): average time (in s) that memory state is valid
-                                    or ( time_average(float), time_stdev(float) ) tuple
+            coherence_time (float): average time (in s) that memory state is valid.
             wavelength (int): wavelength (in nm) of photons emitted by memories.
             qstate_key (int): key for associated quantum state in timeline's quantum manager.
         """
@@ -141,23 +138,7 @@ class Memory(Entity):
         self.raw_fidelity = fidelity
         self.frequency = frequency
         self.efficiency = efficiency
-        # coherence time in seconds
-        if not type( coherence_time ) is tuple:
-            self.coherence_time = coherence_time
-            self.random_coherence_time = False
-        else:
-            self.coherence_time = coherence_time[0]
-            self.coherence_time_stdev = coherence_time[1]
-            self.random_coherence_time = ( self.coherence_time_stdev > 0.0 and
-                                          self.coherence_time > 0.0 )
-            
-        if self.random_coherence_time:
-            self.coherence_time_distribution = lambda: stats.truncnorm.rvs(
-                -0.95 * self.coherence_time / self.coherence_time_stdev,
-                19.0 * self.coherence_time / self.coherence_time_stdev,
-                self.coherence_time,
-                self.coherence_time_stdev )
-        
+        self.coherence_time = coherence_time  # coherence time in seconds
         self.wavelength = wavelength
         self.qstate_key = timeline.quantum_manager.new()
 
@@ -276,10 +257,8 @@ class Memory(Entity):
     def _schedule_expiration(self) -> None:
         if self.expiration_event is not None:
             self.timeline.remove_event(self.expiration_event)
-            
-        coherence_period = self.coherence_time_distribution() if self.random_coherence_time else self.coherence_time
 
-        decay_time = self.timeline.now() + int(coherence_period * 1e12)
+        decay_time = self.timeline.now() + int(self.coherence_time * 1e12)
         process = Process(self, "expire", [])
         event = Event(decay_time, process)
         self.timeline.schedule(event)
@@ -314,3 +293,70 @@ class Memory(Entity):
     def detach(self, observer: 'EntanglementProtocol'):
         if observer in self._observers:
             self._observers.remove(observer)
+
+class MemoryWithRandomCoherenceTime(Memory):
+    """Individual single-atom memory.
+
+    This class models a single-atom memory, where the quantum state is stored as the spin of a single ion.
+    This class will replace the older implementation once completed.
+
+    Attributes:
+        name (str): label for memory instance.
+        timeline (Timeline): timeline for simulation.
+        fidelity (float): (current) fidelity of memory.
+        frequency (float): maximum frequency at which memory can be excited.
+        efficiency (float): probability of emitting a photon when excited.
+        coherence_time (float): average usable lifetime of memory (in seconds).
+        coherence_time_stdev (float): standard deviation of coherence time
+        wavelength (float): wavelength (in nm) of emitted photons.
+        qstate (QuantumState): quantum state of memory.
+        entangled_memory (Dict[str, Any]): tracks entanglement state of memory.
+    """
+
+    def __init__(self, name: str, timeline: "Timeline", fidelity: float, frequency: float,
+                 efficiency: float, coherence_time: float, coherence_time_stdev: float, wavelength: int):
+        """Constructor for the Memory class.
+
+        Args:
+            name (str): name of the memory instance.
+            timeline (Timeline): simulation timeline.
+            fidelity (float): fidelity of memory.
+            frequency (float): maximum frequency of excitation for memory.
+            efficiency (float): efficiency of memories.
+            coherence_time (float): average time (in s) that memory state is valid
+            coherence_time_stdev (float): standard deviation of coherence time
+            wavelength (int): wavelength (in nm) of photons emitted by memories.
+            qstate_key (int): key for associated quantum state in timeline's quantum manager.
+        """
+
+        super(MemoryWithRandomCoherenceTime, self).__init__(name, timeline, fidelity, frequency, 
+                         efficiency, coherence_time, wavelength)
+        
+        # coherence time standard deviation in seconds
+        self.coherence_time_stdev = coherence_time_stdev
+        self.random_coherence_time = ( coherence_time_stdev > 0.0 and
+                                      self.coherence_time > 0.0 )
+        
+    def coherence_time_distribution(self) -> None:
+        return stats.truncnorm.rvs(
+            -0.95 * self.coherence_time / self.coherence_time_stdev,
+            19.0 * self.coherence_time / self.coherence_time_stdev,
+            self.coherence_time,
+            self.coherence_time_stdev )        
+
+    def _schedule_expiration(self) -> None:
+        if self.expiration_event is not None:
+            self.timeline.remove_event(self.expiration_event)
+            
+        coherence_period = ( self.coherence_time_distribution() 
+                            if self.random_coherence_time else 
+                            self.coherence_time )
+
+        decay_time = self.timeline.now() + int(coherence_period * 1e12)
+        process = Process(self, "expire", [])
+        event = Event(decay_time, process)
+        self.timeline.schedule(event)
+
+        self.expiration_event = event
+
+

--- a/src/components/memory.py
+++ b/src/components/memory.py
@@ -257,6 +257,11 @@ class Memory(Entity):
     def _schedule_expiration(self) -> None:
         if self.expiration_event is not None:
             self.timeline.remove_event(self.expiration_event)
+<<<<<<< HEAD
+=======
+            
+        coherence_period = self.coherence_time_distribution() if self.random_coherence_time else self.coherence_time
+>>>>>>> 2f52b6f3ba8650994c6fd47690a1ab92d2d23f0f
 
         decay_time = self.timeline.now() + int(self.coherence_time * 1e12)
         process = Process(self, "expire", [])
@@ -293,6 +298,7 @@ class Memory(Entity):
     def detach(self, observer: 'EntanglementProtocol'):
         if observer in self._observers:
             self._observers.remove(observer)
+<<<<<<< HEAD
 
 class MemoryWithRandomCoherenceTime(Memory):
     """Individual single-atom memory.
@@ -360,3 +366,5 @@ class MemoryWithRandomCoherenceTime(Memory):
         self.expiration_event = event
 
 
+=======
+>>>>>>> 2f52b6f3ba8650994c6fd47690a1ab92d2d23f0f

--- a/tests/components/test_memory.py
+++ b/tests/components/test_memory.py
@@ -1,5 +1,6 @@
 from typing import Dict
 import numpy as np
+import scipy as sp
 import math
 
 from sequence.components.memory import Memory, MemoryArray
@@ -185,3 +186,48 @@ def test_Memory__schedule_expiration():
         if event.is_invalid():
             counter += 1
     assert counter == 1
+    
+def test_Memory__schedule_expiration_random():
+    NUM_TRIALS = 200
+    coherence_period_avg = 1
+    coherence_period_stdev = 0.15
+    tl = Timeline()
+    mem = Memory("mem", tl, fidelity=1, frequency=0, efficiency=1, 
+                 coherence_time=(coherence_period_avg,coherence_period_stdev), 
+                 wavelength=500)
+    parent = DumbParent(mem)
+    
+    times_of_expiration_calculated = [0]
+    np.random.seed(2)
+    for i in range( NUM_TRIALS ):
+        times_of_expiration_calculated.append( times_of_expiration_calculated[-1]
+                                              + int(mem.coherence_time_distribution()*1e12) )
+    times_of_expiration_calculated.pop(0)
+    
+    np.random.seed(2)
+    process = Process(mem, "update_state", [[complex(math.sqrt(1/2)), complex(math.sqrt(1/2))]])
+    for i in range(NUM_TRIALS):
+        event = Event(tl.now(), process)
+        tl.schedule(event)        
+        tl.init()
+        tl.run()
+        assert times_of_expiration_calculated[i] == tl.now()
+        
+    sumX = times_of_expiration_calculated[0]
+    sumXX = times_of_expiration_calculated[0]**2
+    for i in range( 1, len( times_of_expiration_calculated ) ):
+        x = times_of_expiration_calculated[i]-times_of_expiration_calculated[i-1]
+        sumX += x
+        sumXX += x*x
+    
+    avg_simulated = sumX / NUM_TRIALS * 1e-12
+    stdev_simulated = np.sqrt( ( sumXX - sumX * sumX * 1.0/NUM_TRIALS ) / NUM_TRIALS )*1e-12
+    print( 'input avg. =', coherence_period_avg )
+    print( 'input st. dev. =', coherence_period_stdev )
+    print( 'simulated avg. =', avg_simulated )
+    print( 'simulated st. dev. =', stdev_simulated )
+    #check that values in series are different
+    assert stdev_simulated > 0.0
+    #probability of error below is less then 0.3%
+    assert abs( avg_simulated - coherence_period_avg ) < 3 * coherence_period_stdev / np.sqrt( NUM_TRIALS )
+

--- a/tests/components/test_memory.py
+++ b/tests/components/test_memory.py
@@ -204,7 +204,7 @@ def test_MemoryWithRandomCoherenceTime__schedule_expiration():
     times_of_expiration_calculated.pop(0)
     
     np.random.seed(2)
-    process = Process(mem, "update_state", [[complex(math.sqrt(1/2)), complex(math.sqrt(1/2))]])
+    process = Process(mem, "update_state", [2 * [complex(math.sqrt(1/2))]])
     for i in range(NUM_TRIALS):
         event = Event(tl.now(), process)
         tl.schedule(event)        
@@ -219,11 +219,16 @@ def test_MemoryWithRandomCoherenceTime__schedule_expiration():
         period_sum += period
         period_squared_sum += period*period
     
+<<<<<<< HEAD
     avg_simulated = period_sum / NUM_TRIALS * 1e-12
     stdev_simulated = np.sqrt( ( period_squared_sum - period_sum * period_sum * 1.0/NUM_TRIALS ) / NUM_TRIALS )*1e-12
+=======
+    avg_simulated = sumX / NUM_TRIALS * 1e-12
+    stdev_simulated = np.sqrt( ( sumXX - sumX * sumX * 1.0/NUM_TRIALS ) / NUM_TRIALS )*1e-12
+
+>>>>>>> 2f52b6f3ba8650994c6fd47690a1ab92d2d23f0f
 
     #check that values in series are different
     assert stdev_simulated > 0.0
     #probability of error below is less then 0.3%
     assert abs( avg_simulated - coherence_period_avg ) < 3 * coherence_period_stdev / np.sqrt( NUM_TRIALS )
-

--- a/tests/components/test_memory.py
+++ b/tests/components/test_memory.py
@@ -1,6 +1,5 @@
 from typing import Dict
 import numpy as np
-import scipy as sp
 import math
 
 from sequence.components.memory import Memory, MemoryArray
@@ -222,10 +221,12 @@ def test_Memory__schedule_expiration_random():
     
     avg_simulated = sumX / NUM_TRIALS * 1e-12
     stdev_simulated = np.sqrt( ( sumXX - sumX * sumX * 1.0/NUM_TRIALS ) / NUM_TRIALS )*1e-12
-    print( 'input avg. =', coherence_period_avg )
-    print( 'input st. dev. =', coherence_period_stdev )
-    print( 'simulated avg. =', avg_simulated )
-    print( 'simulated st. dev. =', stdev_simulated )
+
+    #print( 'input avg. =', coherence_period_avg )
+    #print( 'input st. dev. =', coherence_period_stdev )
+    #print( 'simulated avg. =', avg_simulated )
+    #print( 'simulated st. dev. =', stdev_simulated )
+
     #check that values in series are different
     assert stdev_simulated > 0.0
     #probability of error below is less then 0.3%

--- a/tests/components/test_memory.py
+++ b/tests/components/test_memory.py
@@ -2,7 +2,7 @@ from typing import Dict
 import numpy as np
 import math
 
-from sequence.components.memory import Memory, MemoryArray
+from sequence.components.memory import Memory, MemoryArray, MemoryWithRandomCoherenceTime
 from sequence.kernel.event import Event
 from sequence.kernel.process import Process
 from sequence.kernel.timeline import Timeline
@@ -186,13 +186,13 @@ def test_Memory__schedule_expiration():
             counter += 1
     assert counter == 1
     
-def test_Memory__schedule_expiration_random():
+def test_MemoryWithRandomCoherenceTime__schedule_expiration():
     NUM_TRIALS = 200
     coherence_period_avg = 1
     coherence_period_stdev = 0.15
     tl = Timeline()
-    mem = Memory("mem", tl, fidelity=1, frequency=0, efficiency=1, 
-                 coherence_time=(coherence_period_avg,coherence_period_stdev), 
+    mem = MemoryWithRandomCoherenceTime("mem", tl, fidelity=1, frequency=0, efficiency=1, 
+                 coherence_time=coherence_period_avg, coherence_time_stdev=coherence_period_stdev, 
                  wavelength=500)
     parent = DumbParent(mem)
     
@@ -204,7 +204,7 @@ def test_Memory__schedule_expiration_random():
     times_of_expiration_calculated.pop(0)
     
     np.random.seed(2)
-    process = Process(mem, "update_state", [2 * [complex(math.sqrt(1/2))]])
+    process = Process(mem, "update_state", [[complex(math.sqrt(1/2)), complex(math.sqrt(1/2))]])
     for i in range(NUM_TRIALS):
         event = Event(tl.now(), process)
         tl.schedule(event)        
@@ -212,18 +212,18 @@ def test_Memory__schedule_expiration_random():
         tl.run()
         assert times_of_expiration_calculated[i] == tl.now()
         
-    sumX = times_of_expiration_calculated[0]
-    sumXX = times_of_expiration_calculated[0]**2
+    period_sum = times_of_expiration_calculated[0]
+    period_squared_sum = times_of_expiration_calculated[0]**2
     for i in range( 1, len( times_of_expiration_calculated ) ):
-        x = times_of_expiration_calculated[i]-times_of_expiration_calculated[i-1]
-        sumX += x
-        sumXX += x*x
+        period = times_of_expiration_calculated[i]-times_of_expiration_calculated[i-1]
+        period_sum += period
+        period_squared_sum += period*period
     
-    avg_simulated = sumX / NUM_TRIALS * 1e-12
-    stdev_simulated = np.sqrt( ( sumXX - sumX * sumX * 1.0/NUM_TRIALS ) / NUM_TRIALS )*1e-12
-
+    avg_simulated = period_sum / NUM_TRIALS * 1e-12
+    stdev_simulated = np.sqrt( ( period_squared_sum - period_sum * period_sum * 1.0/NUM_TRIALS ) / NUM_TRIALS )*1e-12
 
     #check that values in series are different
     assert stdev_simulated > 0.0
     #probability of error below is less then 0.3%
     assert abs( avg_simulated - coherence_period_avg ) < 3 * coherence_period_stdev / np.sqrt( NUM_TRIALS )
+

--- a/tests/components/test_memory.py
+++ b/tests/components/test_memory.py
@@ -2,7 +2,7 @@ from typing import Dict
 import numpy as np
 import math
 
-from sequence.components.memory import Memory, MemoryArray
+from sequence.components.memory import Memory, MemoryArray, MemoryWithRandomCoherenceTime
 from sequence.kernel.event import Event
 from sequence.kernel.process import Process
 from sequence.kernel.timeline import Timeline
@@ -186,13 +186,13 @@ def test_Memory__schedule_expiration():
             counter += 1
     assert counter == 1
     
-def test_Memory__schedule_expiration_random():
+def test_MemoryWithRandomCoherenceTime__schedule_expiration():
     NUM_TRIALS = 200
     coherence_period_avg = 1
     coherence_period_stdev = 0.15
     tl = Timeline()
-    mem = Memory("mem", tl, fidelity=1, frequency=0, efficiency=1, 
-                 coherence_time=(coherence_period_avg,coherence_period_stdev), 
+    mem = MemoryWithRandomCoherenceTime("mem", tl, fidelity=1, frequency=0, efficiency=1, 
+                 coherence_time=coherence_period_avg, coherence_time_stdev=coherence_period_stdev, 
                  wavelength=500)
     parent = DumbParent(mem)
     
@@ -212,20 +212,15 @@ def test_Memory__schedule_expiration_random():
         tl.run()
         assert times_of_expiration_calculated[i] == tl.now()
         
-    sumX = times_of_expiration_calculated[0]
-    sumXX = times_of_expiration_calculated[0]**2
+    period_sum = times_of_expiration_calculated[0]
+    period_squared_sum = times_of_expiration_calculated[0]**2
     for i in range( 1, len( times_of_expiration_calculated ) ):
-        x = times_of_expiration_calculated[i]-times_of_expiration_calculated[i-1]
-        sumX += x
-        sumXX += x*x
+        period = times_of_expiration_calculated[i]-times_of_expiration_calculated[i-1]
+        period_sum += period
+        period_squared_sum += period*period
     
-    avg_simulated = sumX / NUM_TRIALS * 1e-12
-    stdev_simulated = np.sqrt( ( sumXX - sumX * sumX * 1.0/NUM_TRIALS ) / NUM_TRIALS )*1e-12
-
-    #print( 'input avg. =', coherence_period_avg )
-    #print( 'input st. dev. =', coherence_period_stdev )
-    #print( 'simulated avg. =', avg_simulated )
-    #print( 'simulated st. dev. =', stdev_simulated )
+    avg_simulated = period_sum / NUM_TRIALS * 1e-12
+    stdev_simulated = np.sqrt( ( period_squared_sum - period_sum * period_sum * 1.0/NUM_TRIALS ) / NUM_TRIALS )*1e-12
 
     #check that values in series are different
     assert stdev_simulated > 0.0


### PR DESCRIPTION
Now it's possible to pass both average time (as before) or tuple with the average time and its standard deviation. I don't know how to organize correctly namespace in test_memory.py but I hope its current version is not too far from what you need.