### PR TITLE
Allow events to use the name of entity as the owner

### DIFF
--- a/src/kernel/timeline.py
+++ b/src/kernel/timeline.py
@@ -9,12 +9,13 @@ from datetime import timedelta
 from math import inf
 from sys import stdout
 from time import time_ns, sleep
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Dict, Union
 
 from numpy import random
 
 if TYPE_CHECKING:
     from .event import Event
+    from .entity import Entity
 
 from .eventlist import EventList
 from ..utils import log
@@ -63,14 +64,14 @@ class Timeline:
         Args:
             stop_time (int): stop time (in ps) of simulation (default inf).
         """
-        self.events = EventList()
-        self.entities = {}
-        self.time = 0
-        self.stop_time = stop_time
-        self.schedule_counter = 0
-        self.run_counter = 0
-        self.is_running = False
-        self.show_progress = False
+        self.events: EventList = EventList()
+        self.entities: Dict[str, "Entity"] = {}
+        self.time: Union[int, float] = 0
+        self.stop_time: Union[int, float] = stop_time
+        self.schedule_counter: int = 0
+        self.run_counter: int = 0
+        self.is_running: bool = False
+        self.show_progress: bool = False
 
         if formalism == KET_STATE_FORMALISM:
             self.quantum_manager = QuantumManagerKet()
@@ -86,7 +87,8 @@ class Timeline:
 
     def schedule(self, event: "Event") -> None:
         """Method to schedule an event."""
-
+        if type(event.process.owner) is str:
+            event.process.owner = self.get_entity_by_name(event.process.owner)
         self.schedule_counter += 1
         self.events.push(event)
 

--- a/tests/kernel/test_timeline.py
+++ b/tests/kernel/test_timeline.py
@@ -126,3 +126,23 @@ def test_get_entity_by_name():
     e1 = Dummy("e1", tl)
     assert tl.get_entity_by_name("e1") == e1
     assert tl.get_entity_by_name("e2") is None
+
+
+def test_schedule():
+    ENTITY_NAME = "dummy"
+    SCHEDULE_NUM = 100
+
+    tl = Timeline()
+    e1 = Dummy(ENTITY_NAME, tl)
+
+    for i in range(SCHEDULE_NUM):
+        if i % 2:
+            # schedule event by entity object
+            tl.schedule(Event(0, Process(e1, "operate", [])))
+        else:
+            # schedule event by entity name
+            tl.schedule(Event(0, Process(ENTITY_NAME, "operate", [])))
+    assert tl.schedule_counter == SCHEDULE_NUM
+    tl.init()
+    tl.run()
+    assert tl.run_counter == SCHEDULE_NUM == e1.counter


### PR DESCRIPTION
* Function `Timeline.schedule` automatically change the name of entity to the object of entity when it detects the owner of event is string
* add unit test for function `Timeline.schedule` 
* claim type of attributes of Timeline