### PR TITLE
Fix workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: main
 
 on:
   push:
-    branches: [master, RnD]
+    branches: [master, RnD, fix_workflow]
   pull_request:
     branches: [master. RnD]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: main
 
 on:
   push:
-    branches: [master, RnD, fix_workflow]
+    branches: [master, RnD]
   pull_request:
     branches: [master. RnD]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy<1.22
 matplotlib
 json5==0.8.4
 pandas


### PR DESCRIPTION
The most recent numpy release (1.22) is incompatible with qutip, causing issues on import. The version has been changed to <1.22 in the requirements file. Also of note is that this version removes support for python 3.7.