### PR TITLE
fix inconsistent formalism used in the ParallelTimeline

### DIFF
--- a/src/kernel/p_timeline.py
+++ b/src/kernel/p_timeline.py
@@ -6,6 +6,7 @@ from time import time
 from .timeline import Timeline
 from .event import Event
 from .quantum_manager_client import QuantumManagerClient
+from .quantum_manager import KET_STATE_FORMALISM
 
 
 class ParallelTimeline(Timeline):
@@ -26,7 +27,8 @@ class ParallelTimeline(Timeline):
         quantum_manager (QuantumManagerClient): local quantum manager client to communicate with server.
     """
 
-    def __init__(self, lookahead: int, stop_time=float('inf'), formalism='KET',
+    def __init__(self, lookahead: int, stop_time=float('inf'),
+                 formalism=KET_STATE_FORMALISM,
                  qm_ip=None, qm_port=None):
         """Constructor for the ParallelTimeline class.
 


### PR DESCRIPTION
use `KET_STATE_FORMALISM` instead of raw string to represent formalism used in the ParallelTimeline