### PR TITLE
Small modification of ./docs/source/conf.py for MacOS users.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,7 +43,7 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = []
+exclude_patterns = ['Thumbs.db', '.DS_Store']
 
 source_suffix = {
         '.rst': 'restructuredtext',


### PR DESCRIPTION
OS: MacOS _ Sonoma 14.5

Issue: Error and additional warnings are generated due to DS_Store file which is generated by MacOS (It is used to store custom attributes of its containing folder, such as folder view options, icon positions, and other visual information.).

Solution: Modification of line 46.