### PR TITLE
logging added to tutorial

### DIFF
--- a/docs/source/tutorial/chapter0/prerequisite.md
+++ b/docs/source/tutorial/chapter0/prerequisite.md
@@ -6,7 +6,7 @@ Thank you for downloading SeQUeNCe and welcome to the tutorial section of the do
 
 ### Python Version
 
-The simulator requires at least version **3.9** of Python. This can be found at the [Python Website](https://www.python.org/downloads/).
+The simulator requires at least version **3.10** of Python. This can be found at the [Python Website](https://www.python.org/downloads/).
 
 ### Dependencies
 

--- a/example/bb84_logging.py
+++ b/example/bb84_logging.py
@@ -21,7 +21,7 @@ tl.show_progress = True
 log.set_logger(__name__, tl, log_filename)
 log.set_logger_level('DEBUG')
 log.track_module('BB84')
-log.track_module('timeline')
+# log.track_module('timeline')
 log.track_module('light_source')
 
 qc0 = QuantumChannel("qc0", tl, distance=distance, polarization_fidelity=0.97, attenuation=0.0002)


### PR DESCRIPTION
I added a subsection at the end of tutorial chapter 1 in which I described how to implement sequence's variant of logging for the 'store' example used in that chapter.