### PR TITLE
adding epsilon to optical channel to avoid float division issues

### DIFF
--- a/sequence/components/optical_channel.py
+++ b/sequence/components/optical_channel.py
@@ -20,7 +20,7 @@ from ..kernel.entity import Entity
 from ..kernel.event import Event
 from ..kernel.process import Process
 from ..utils import log
-from ..constants import SPEED_OF_LIGHT, MICROSECOND
+from ..constants import SPEED_OF_LIGHT, MICROSECOND, EPSILON
 
 
 class OpticalChannel(Entity):
@@ -200,8 +200,8 @@ class QuantumChannel(OpticalChannel):
         # TODO: move this to node?
 
         min_time = max(min_time, self.timeline.now())
-        time_bin = min_time * (self.frequency / 1e12)
-        if time_bin - int(time_bin) > 0.00001:
+        time_bin = (min_time * self.frequency)/1e12
+        if time_bin - int(time_bin) > EPSILON:
             time_bin = int(time_bin) + 1       # round to the next time bin
         else:
             time_bin = int(time_bin)

--- a/sequence/constants.py
+++ b/sequence/constants.py
@@ -17,7 +17,7 @@ PSI_PLUS:  Final = (0, SQRT_HALF,  SQRT_HALF, 0)
 PSI_MINUS: Final = (0, SQRT_HALF, -SQRT_HALF, 0)
 
 # machine epsilon, i.e., a small number
-EPSILON: Final = 1e-7
+EPSILON: Final = 1e-8
 
 # convert to picosecond
 NANOSECOND:  Final = 1e3


### PR DESCRIPTION
`schedule_transmit` method in `QuantumChannel` class compares a float and its int within some small but not small enough number and I changed this to EPSILON (setting it to 1e-8) to ensure there aren't any float division issues (which I experienced).