### PR TITLE
[minor] Fix Event Priority Issue in EntanglementGenerationA.received_message()

### DIFF
--- a/sequence/entanglement_management/generation.py
+++ b/sequence/entanglement_management/generation.py
@@ -297,7 +297,8 @@ class EntanglementGenerationA(EntanglementProtocol):
                 process = Process(self, "start", [])  # for the second round
             else:
                 process = Process(self, "update_memory", [])
-            event = Event(future_start_time, process)
+            priority = self.owner.timeline.schedule_counter
+            event = Event(future_start_time, process, priority)
             self.owner.timeline.schedule(event)
             self.scheduled_events.append(event)
 
@@ -325,7 +326,8 @@ class EntanglementGenerationA(EntanglementProtocol):
                 process = Process(self, "start", [])  # for the second round
             else:
                 process = Process(self, "update_memory", [])
-            event = Event(future_start_time, process)
+            priority = self.owner.timeline.schedule_counter
+            event = Event(future_start_time, process, priority)
             self.owner.timeline.schedule(event)
             self.scheduled_events.append(event)
 


### PR DESCRIPTION
In EntanglementGenerationA.received_message(), update the priority of the events for future start. To resolve an issue for the edge case when the BSM node is at the end nodes, i.e., distance to one end node is zero.