### PR TITLE
265-skip-publish-to-testpypi

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -12,6 +12,7 @@ env:
 
 jobs:
   build-rnd:
+    if: github.repository == 'sequence-toolbox/SeQUeNCe'
     name: Build RnD Package
     runs-on: ubuntu-latest
     outputs:
@@ -79,7 +80,7 @@ jobs:
     name: Publish RnD to TestPyPI and PyPI
     needs: build-rnd
     runs-on: ubuntu-latest
-    if: success()
+    if: success() && github.repository == 'sequence-toolbox/SeQUeNCe'
 
     strategy:
       matrix:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
   build-release:
     name: Build the release
     runs-on: ubuntu-latest
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' && github.repository == 'sequence-toolbox/SeQUeNCe'
     steps:
       - uses: actions/checkout@v5
         with:
@@ -37,7 +37,7 @@ jobs:
   build-test-release:
     name: Build the test release
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.repository == 'sequence-toolbox/SeQUeNCe'
     steps:
       - uses: actions/checkout@v5
         with:
@@ -65,7 +65,7 @@ jobs:
 
   publish-to-pypi:
     name: Publish dist to PyPi
-    if: github.event_name == 'release' && github.event.action == 'published'
+    if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'sequence-toolbox/SeQUeNCe'
     needs:
       - build-release
     runs-on: ubuntu-latest
@@ -86,7 +86,7 @@ jobs:
 
   publish-to-test-pypi:
     name: Publish dist to TestPyPi
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.repository == 'sequence-toolbox/SeQUeNCe'
     needs:
       - build-test-release
     runs-on: ubuntu-latest

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   validation:
+    if: github.repository == 'sequence-toolbox/SeQUeNCe'
     name: Run Unit Tests
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Restrict the CI/CD pipeline from executing on forks. Ensures no actions cost to user/developer.