### PR TITLE
Update purification protocol

### DIFF
--- a/sequence/app/request_app.py
+++ b/sequence/app/request_app.py
@@ -117,14 +117,16 @@ class RequestApp:
             info (MemoryInfo): info on the qualified entangled memory.
         """
 
-        if info.state != "ENTANGLED":
+        if info.state not in ["ENTANGLED", "PURIFIED"]:
             return
 
         if info.index in self.memo_to_reservation:
             reservation = self.memo_to_reservation[info.index]
-            if info.remote_node == reservation.initiator and info.fidelity >= reservation.fidelity:
+            check1 = info.remote_node == reservation.initiator
+            check2 = info.remote_node == reservation.responder
+            if check1 and (info.fidelity >= reservation.fidelity or info.state == "PURIFIED"):
                 self.node.resource_manager.update(None, info.memory, "RAW")
-            elif info.remote_node == reservation.responder and info.fidelity >= reservation.fidelity:
+            elif check2 and (info.fidelity >= reservation.fidelity or info.state == "PURIFIED"):
                 self.memory_counter += 1
                 log.logger.info(f"Successfully generated entanglement. Counter is at {self.memory_counter}.")
                 self.node.resource_manager.update(None, info.memory, "RAW")

--- a/sequence/components/memory.py
+++ b/sequence/components/memory.py
@@ -312,7 +312,7 @@ class Memory(Entity):
             Will notify upper entities of expiration via the `pop` interface.
             Will modify the quantum state of the memory.
         """
-
+        #log.logger.debug(f'Memory {self.name} has expired at time {self.timeline.now()}')
         if self.is_in_application:
             pass
 
@@ -411,6 +411,7 @@ class Memory(Entity):
             self.timeline.remove_event(self.expiration_event)
 
         decay_time = self.timeline.now() + int(self.cutoff_ratio * self.coherence_time * 1e12)
+        #log.logger.debug(f'Memory {self.name} is set to expire at time {decay_time}')
         process = Process(self, "expire", [])
         event = Event(decay_time, process)
         self.timeline.schedule(event)
@@ -425,7 +426,7 @@ class Memory(Entity):
         Args:
             time (int): new expiration time.
         """
-
+        #log.logger.debug(f'Memory expiry is updated')
         time = max(time, self.timeline.now())
         if self.expiration_event is None:
             if time >= self.timeline.now():

--- a/sequence/entanglement_management/purification/bbpssw_protocol.py
+++ b/sequence/entanglement_management/purification/bbpssw_protocol.py
@@ -29,9 +29,10 @@ class BBPSSWMessage(Message):
         receiver (str): name of destination protocol instance.
     """
 
-    def __init__(self, msg_type: BBPSSWMsgType, receiver: str, meas_res: int, **kwargs):
+    def __init__(self, msg_type: BBPSSWMsgType, receiver: str, meas_res: int, protocol_type: str):
         super().__init__(msg_type, receiver)
         self.meas_res = meas_res
+        self.protocol_type = protocol_type
 
     def __str__(self):
         return f"\"BBPSSW: type={self.msg_type}, meas_res={self.meas_res}\""
@@ -58,6 +59,7 @@ class BBPSSWProtocol(EntanglementProtocol, ABC):
         self.remote_node_name: str = ''
         self.remote_protocol_name: str = ''
         self.remote_memories: list[str] = []
+        self.protocol_type = 'bbpssw'
         self.meas_res = None
         if self.meas_memo is None:
             self.memories.pop()

--- a/sequence/kernel/process.py
+++ b/sequence/kernel/process.py
@@ -19,6 +19,7 @@ class Process:
 
     def __init__(self, owner: Any, activation_method: str, activation_args: list[Any], activation_kwargs: dict[Any, Any] = {}):
         self.owner = owner
+        self.number = None
         self.activation = activation_method
         self.activation_args = activation_args
         self.activation_kwargs = activation_kwargs

--- a/sequence/kernel/timeline.py
+++ b/sequence/kernel/timeline.py
@@ -84,6 +84,9 @@ class Timeline:
         if type(event.process.owner) is str:
             event.process.owner = self.get_entity_by_name(event.process.owner)
         self.schedule_counter += 1
+        event.process.number = self.schedule_counter
+        if event.process.activation == 'expire':
+            log.logger.debug(f'Scheduled expiry with ID:#{event.process.number}: Process owner={event.process.owner}, at time {event.time}')  # Log scheduled events
         self.events.push(event)
 
     def init(self) -> None:
@@ -117,7 +120,9 @@ class Timeline:
                 continue
 
             self.time = event.time
-            
+            if event.process.activation == 'expire':
+                log.logger.debug(
+                    f"Event #{self.run_counter}: executing expire event={event.process.number}, process owner={event.process.owner}, activation={event.process.activation}")
             log.logger.debug(f"Event #{self.run_counter}: process owner={event.process.owner}, activation={event.process.activation}")
             event.process.run()
             self.run_counter += 1

--- a/sequence/network_management/reservation.py
+++ b/sequence/network_management/reservation.py
@@ -200,7 +200,7 @@ def ep_rule_condition2(memory_info: "MemoryInfo", manager: "MemoryManager", args
     memory_indices = args["memory_indices"]
     fidelity = args["fidelity"]
 
-    if (memory_info.index in memory_indices and memory_info.state == "ENTANGLED" and memory_info.fidelity < fidelity):
+    if memory_info.index in memory_indices and memory_info.state == "ENTANGLED" and memory_info.fidelity < fidelity:
         return [memory_info]
     return []
 
@@ -254,22 +254,22 @@ def es_rule_conditionA(memory_info: "MemoryInfo", memory_manager: "MemoryManager
     left = args["left"]
     right = args["right"]
     fidelity = args["fidelity"]
-    if (memory_info.state == "ENTANGLED"
+    if (memory_info.state in ["ENTANGLED", "PURIFIED"]
             and memory_info.index in memory_indices
             and memory_info.remote_node == left
             and memory_info.fidelity >= fidelity):
         for memory_info2 in memory_manager:
-            if (memory_info2.state == "ENTANGLED"
+            if (memory_info2.state in ["ENTANGLED", "PURIFIED"]
                     and memory_info2.index in memory_indices
                     and memory_info2.remote_node == right
                     and memory_info2.fidelity >= fidelity):
                 return [memory_info, memory_info2]
-    elif (memory_info.state == "ENTANGLED"
+    elif (memory_info.state in ["ENTANGLED", "PURIFIED"]
             and memory_info.index in memory_indices
             and memory_info.remote_node == right
             and memory_info.fidelity >= fidelity):
         for memory_info2 in memory_manager:
-            if (memory_info2.state == "ENTANGLED"
+            if (memory_info2.state in ["ENTANGLED", "PURIFIED"]
                     and memory_info2.index in memory_indices
                     and memory_info2.remote_node == left
                     and memory_info2.fidelity >= fidelity):
@@ -283,7 +283,7 @@ def es_rule_conditionB1(memory_info: "MemoryInfo", manager: "MemoryManager", arg
     memory_indices = args["memory_indices"]
     target_remote = args["target_remote"]  # A - B - C. For A: B is the remote node, C is the target remote
     fidelity = args["fidelity"]
-    if (memory_info.state == "ENTANGLED"
+    if (memory_info.state in ["ENTANGLED", "PURIFIED"]
             and memory_info.index in memory_indices
             # and memory_info.remote_node != path[-1]
             and memory_info.remote_node != target_remote
@@ -301,7 +301,7 @@ def es_rule_conditionB2(memory_info: "MemoryInfo", manager: "MemoryManager", arg
     left = args["left"]
     right = args["right"]
     fidelity = args["fidelity"]
-    if (memory_info.state == ENTANGLED
+    if (memory_info.state in ["ENTANGLED", "PURIFIED"]
             and memory_info.index in memory_indices
             and memory_info.remote_node not in [left, right]
             and memory_info.fidelity >= fidelity):

--- a/sequence/resource_management/memory_manager.py
+++ b/sequence/resource_management/memory_manager.py
@@ -63,6 +63,8 @@ class MemoryManager:
             info.to_occupied()
         elif state == "ENTANGLED":
             info.to_entangled()
+        elif state == "PURIFIED":
+            info.to_purified()
         else:
             raise Exception("Unknown state '%s'" % state)
 
@@ -107,6 +109,7 @@ class MemoryInfo:
     RAW = "RAW"
     OCCUPIED = "OCCUPIED"
     ENTANGLED = "ENTANGLED"
+    PURIFIED = "PURIFIED"
 
     def __init__(self, memory: "Memory", index: int, state="RAW"):
         """Constructor for memory info class.
@@ -149,6 +152,13 @@ class MemoryInfo:
         """Method to set memory to entangled state."""
 
         self.state = self.ENTANGLED
+        self.remote_node = self.memory.entangled_memory["node_id"]
+        self.remote_memo = self.memory.entangled_memory["memo_id"]
+        self.fidelity = self.memory.fidelity
+        self.entangle_time = self.memory.timeline.now()
+
+    def to_purified(self) -> None:
+        self.state = self.PURIFIED
         self.remote_node = self.memory.entangled_memory["node_id"]
         self.remote_memo = self.memory.entangled_memory["memo_id"]
         self.fidelity = self.memory.fidelity

--- a/sequence/resource_management/resource_manager.py
+++ b/sequence/resource_management/resource_manager.py
@@ -200,7 +200,7 @@ class ResourceManager:
         if protocol in self.pending_protocols:
             self.pending_protocols.remove(protocol)
 
-        # iterate all the ruls and check if there is a valid rule
+        # iterate all the rules and check if there is a valid rule
         memo_info = self.memory_manager.get_info_by_memory(memory)
         for rule in self.rule_manager:
             memories_info = rule.is_valid(memo_info)


### PR DESCRIPTION
Purification had the following issues:
* When coherence time is inf, purification will return success with a fidelity higher than the target.
* When coherence time is finite, purification succeeds but may not ever return pairs with at least target fidelity. Further, as coherence time shrinks, purification will succeed but never return pairs with at least target fidelity. When pairs never reach target fidelity, **the responder node will enter infinite loop of purification until memory expiry while initiator will deliver insufficient pairs to the app and be released.**

This PR implements the following changes:
* Add a purification state, when purification succeeds, the memory is transitioned to "PURIFIED". This new state is identical in function to the "ENTANGLED" state, but can only be triggered by BBPSSW. The result is purification will succeed once, and deliver to the application. This could be modified to allow for more complicated behavior of purification w.r.t delivered fidelity.
* Add tracking for scheduled expiration events by tracking the event ID. 
* The RequestApp is updated to allow counting of entanglement if the pairs are purified, but below the target fidelity.
* Adds protocol type to BBPSSW (unused)