### PR TITLE
Entanglement Swapping BDS Implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0]
+### Added
+- Created the `swapping` module that has the following classes. The subclasses use the registry decorator (factory pattern).
+    - Base class: `EntanglementSwappingA` & `EntanglementSwappingB`
+    - Subclass for ket vector and density matrix: `EntanglementSwappingA_Circuit` & `EntanglementSwappingB_Circuit`
+    - Subclass for Bell diagonal state: `EntanglementSwappingA_BDS` & `EntanglementSwappingB_BDS`
+
+### Removed
+- The old `swapping.py` is removed.
+
+
 ## [0.8.5] - 2026-2-27
 ### Added
 - `NetworkManager` ABC with a factory pattern for selection and future implementation of new network managers.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sequence"
-version = "0.8.5"
+version = "0.8.6"
 authors = [
     { name = "Xiaoliang Wu, Joaquin Chung, Alexander Kolar, Alexander Kiefer, Eugene Wang, Tian Zhong, Rajkumar Kettimuthu, Martin Suchara, Robert Hayek, Ansh Singal, Caitao Zhan", email = "czhan@anl.gov" }
 ]

--- a/sequence/app/request_app.py
+++ b/sequence/app/request_app.py
@@ -146,7 +146,9 @@ class RequestApp:
 
     def schedule_reservation(self, reservation: Reservation) -> None:
         """Calling the `add_memo_reservation_map` and `remove_memo_reservation_map` methods at the 
-           reservation's start_time and end_time for all timecards (memory) involved in the reservation.
+           reservation's start_time and end_time for all timecards (memory) involved in the reservation. 
+           
+           Called by the initiator and the responder when reservation is approved.
 
         Args:
             reservation (Reservation): reservation to schedule

--- a/sequence/components/bsm.py
+++ b/sequence/components/bsm.py
@@ -21,7 +21,7 @@ from .photon import Photon
 from ..kernel.entity import Entity
 from ..kernel.event import Event
 from ..kernel.process import Process
-from ..constants import KET_STATE_FORMALISM, DENSITY_MATRIX_FORMALISM
+from ..constants import KET_VECTOR_FORMALISM, DENSITY_MATRIX_FORMALISM
 from ..utils.encoding import *
 from ..utils import log
 
@@ -54,7 +54,7 @@ def _set_state_with_fidelity(keys: list[int], desired_state: list[complex], fide
                        BSM._psi_plus, BSM._psi_minus]
     assert desired_state in possible_states
 
-    if qm.get_active_formalism() == KET_STATE_FORMALISM:
+    if qm.get_active_formalism() == KET_VECTOR_FORMALISM:
         probabilities = [(1 - fidelity) / 3] * 4
         probabilities[possible_states.index(desired_state)] = fidelity
         state_ind = rng.choice(4, p=probabilities)
@@ -73,7 +73,7 @@ def _set_state_with_fidelity(keys: list[int], desired_state: list[complex], fide
 
 
 def _set_pure_state(keys: list[int], ket_state: list[complex], qm: "QuantumManager"):
-    if qm.get_active_formalism() == KET_STATE_FORMALISM:
+    if qm.get_active_formalism() == KET_VECTOR_FORMALISM:
         qm.set(keys, ket_state)
     elif qm.get_active_formalism() == DENSITY_MATRIX_FORMALISM:
         state = outer(ket_state, ket_state)
@@ -85,7 +85,7 @@ def _set_pure_state(keys: list[int], ket_state: list[complex], qm: "QuantumManag
 
 
 def _eq_psi_plus(state: "State", formalism: str):
-    if formalism == KET_STATE_FORMALISM:
+    if formalism == KET_VECTOR_FORMALISM:
         return array_equal(state.state, BSM._psi_plus)
     elif formalism == DENSITY_MATRIX_FORMALISM:
         d_state = outer(BSM._phi_plus, BSM._psi_plus)

--- a/sequence/constants.py
+++ b/sequence/constants.py
@@ -44,7 +44,7 @@ MILLISECOND: Final = 10**9
 SECOND:      Final = 10**12
 
 #: Built-in ket-vector formalism identifier.
-KET_STATE_FORMALISM: Final = "ket_vector"
+KET_VECTOR_FORMALISM: Final = "ket_vector"
 #: Built-in density-matrix formalism identifier.
 DENSITY_MATRIX_FORMALISM: Final = "density_matrix"
 #: Built-in Fock density-matrix formalism identifier.

--- a/sequence/entanglement_management/__init__.py
+++ b/sequence/entanglement_management/__init__.py
@@ -1,4 +1,4 @@
-__all__ = ['entanglement_protocol', 'generation', 'swapping', 'purification']
+__all__ = ['entanglement_protocol', 'generation', 'swapping', 'purification', 'teleportation']
 
 def __dir__():
     return sorted(__all__)

--- a/sequence/entanglement_management/entanglement_protocol.py
+++ b/sequence/entanglement_management/entanglement_protocol.py
@@ -18,12 +18,13 @@ class EntanglementProtocol(Protocol):
     Attributes:
         owner (Node): Node object to attach to
         name (str): Name of the protocol instance
+        protocol_type (str): Type of the protocol instance
         rule (Rule): Rule which created this protocol instance (from the rule manager).
         memories (list[Memory]): Any memories being operated on
     """
 
-    def __init__(self, owner: "Node", name: str):
-        super().__init__(owner, name)
+    def __init__(self, owner: "Node", name: str, protocol_type: str = ""):
+        super().__init__(owner, name, protocol_type)
         self.rule = None
         self.memories = []
 

--- a/sequence/entanglement_management/generation/generation_base.py
+++ b/sequence/entanglement_management/generation/generation_base.py
@@ -54,8 +54,7 @@ class EntanglementGenerationA(EntanglementProtocol, ABC):
     _global_type: str = BARRET_KOK
 
     def __init__(self, owner: "Node", name: str, middle: str, other: str, memory: "Memory", **kwargs):
-        super().__init__(owner, name)
-        self.protocol_type = BARRET_KOK
+        super().__init__(owner, name, BARRET_KOK)
         self.middle: str = middle
         self.remote_node_name: str = other
         self.remote_protocol_name: str = ''

--- a/sequence/entanglement_management/purification/bbpssw_circuit.py
+++ b/sequence/entanglement_management/purification/bbpssw_circuit.py
@@ -15,10 +15,10 @@ if TYPE_CHECKING:
     from ...topology.node import Node
 
 from ...utils import log
-from ...constants import KET_STATE_FORMALISM, DENSITY_MATRIX_FORMALISM
+from ...constants import KET_VECTOR_FORMALISM, DENSITY_MATRIX_FORMALISM
 from .bbpssw_protocol import BBPSSWProtocol, BBPSSWMessage, BBPSSWMsgType
 
-@BBPSSWProtocol.register(KET_STATE_FORMALISM)
+@BBPSSWProtocol.register(KET_VECTOR_FORMALISM)
 @BBPSSWProtocol.register(DENSITY_MATRIX_FORMALISM)
 class BBPSSWCircuit(BBPSSWProtocol):
     """Purification protocol instance.

--- a/sequence/entanglement_management/purification/bbpssw_protocol.py
+++ b/sequence/entanglement_management/purification/bbpssw_protocol.py
@@ -1,12 +1,14 @@
+"""Base class for BBPSSW entanglement purification protocol.
+"""
 from __future__ import annotations
 from abc import ABC, abstractmethod
 from enum import Enum, auto
-from typing import TYPE_CHECKING, List, Dict, Type, Optional
+from typing import TYPE_CHECKING
 from collections.abc import Callable
 
 from sequence.entanglement_management.entanglement_protocol import EntanglementProtocol
 from sequence.utils.log import logger
-from ...constants import KET_STATE_FORMALISM
+from ...constants import KET_VECTOR_FORMALISM
 from ...message import Message
 
 if TYPE_CHECKING:
@@ -41,7 +43,7 @@ class BBPSSWMessage(Message):
 
 class BBPSSWProtocol(EntanglementProtocol, ABC):
     _registry: dict[str, type['BBPSSWProtocol']] = {}
-    _global_formalism: str = KET_STATE_FORMALISM
+    _global_formalism: str = KET_VECTOR_FORMALISM
 
     def __init__(self, owner: Node, name: str, kept_memo: Memory, meas_memo: Memory, **kwargs):
         """Constructor for purification protocol.
@@ -53,14 +55,13 @@ class BBPSSWProtocol(EntanglementProtocol, ABC):
             meas_memo (Memory): Memory to measure and discard.
         """
         assert kept_memo != meas_memo
-        super().__init__(owner, name)
+        super().__init__(owner, name, 'bbpssw')
         self.memories: list[Memory] = [kept_memo, meas_memo]
         self.kept_memo: Memory = kept_memo
         self.meas_memo: Memory = meas_memo
         self.remote_node_name: str = ''
         self.remote_protocol_name: str = ''
         self.remote_memories: list[str] = []
-        self.protocol_type = 'bbpssw'
         self.meas_res = None
         if self.meas_memo is None:
             self.memories.pop()
@@ -158,7 +159,7 @@ class BBPSSWProtocol(EntanglementProtocol, ABC):
     @classmethod
     def clear_global_formalism(cls) -> None:
         """Resets the global formalism to default"""
-        cls._global_formalism = KET_STATE_FORMALISM
+        cls._global_formalism = KET_VECTOR_FORMALISM
 
     def is_ready(self) -> bool:
         """Check if the protocol is ready to start."""

--- a/sequence/entanglement_management/swapping/__init__.py
+++ b/sequence/entanglement_management/swapping/__init__.py
@@ -1,0 +1,9 @@
+from .swapping_base import EntanglementSwappingA, EntanglementSwappingB, SwappingMsgType, EntanglementSwappingMessage
+from .swapping_circuit import EntanglementSwappingA_Circuit, EntanglementSwappingB_Circuit
+from .swapping_bds import EntanglementSwappingA_BDS, EntanglementSwappingB_BDS
+
+__all__ = ['EntanglementSwappingA', 'EntanglementSwappingB', 'SwappingMsgType', 'EntanglementSwappingMessage', 'EntanglementSwappingA_Circuit', 
+           'EntanglementSwappingB_Circuit', 'EntanglementSwappingA_BDS', 'EntanglementSwappingB_BDS']
+
+def __dir__():
+    return sorted(__all__)

--- a/sequence/entanglement_management/swapping/swapping_base.py
+++ b/sequence/entanglement_management/swapping/swapping_base.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 from ..entanglement_protocol import EntanglementProtocol
 from ...constants import KET_VECTOR_FORMALISM
 from ...message import Message
+from ...resource_management.memory_manager import MemoryInfo
 from ...utils import log
 
 if TYPE_CHECKING:
@@ -239,9 +240,9 @@ class EntanglementSwappingA(EntanglementProtocol, ABC):
 
         for memo in self.memories:
             if memo == memory:
-                self.update_resource_manager(memo, "RAW")
+                self.update_resource_manager(memo, MemoryInfo.RAW)
             else:
-                self.update_resource_manager(memo, "ENTANGLED")
+                self.update_resource_manager(memo, MemoryInfo.ENTANGLED)
 
     def release_remote_protocol(self, remote_node: str):
         self.owner.resource_manager.release_remote_protocol(remote_node, self)
@@ -362,10 +363,10 @@ class EntanglementSwappingB(EntanglementProtocol, ABC):
             Will update memory in attached resource manager.
         """
 
-        self.update_resource_manager(self.memory, "RAW")
+        self.update_resource_manager(self.memory, MemoryInfo.RAW)
 
     def release(self) -> None:
-        self.update_resource_manager(self.memory, "ENTANGLED")
+        self.update_resource_manager(self.memory, MemoryInfo.ENTANGLED)
 
     @abstractmethod
     def received_message(self, src: str, msg: EntanglementSwappingMessage) -> None:

--- a/sequence/entanglement_management/swapping/swapping_base.py
+++ b/sequence/entanglement_management/swapping/swapping_base.py
@@ -1,5 +1,17 @@
 """The base class for entanglement swapping protocol.
+
+This module defines code for entanglement swapping.
+Success rate is pre-determined based on network parameters.
+The entanglement swapping protocol is an asymmetric protocol:
+
+* The EntanglementSwappingA instance initiates the protocol and performs the swapping operation.
+* The EntanglementSwappingB instance waits for the swapping result from EntanglementSwappingA.
+
+The swapping results decide the following operations of EntanglementSwappingB.
+Also defined in this module is the message type used by these protocols.
+
 """
+
 from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Callable
@@ -62,7 +74,7 @@ class EntanglementSwappingA(EntanglementProtocol, ABC):
     _registry: dict[str, type['EntanglementSwappingA']] = {}
     _global_formalism: str = KET_VECTOR_FORMALISM
 
-    def __init__(self, owner: "Node", name: str, left_memo: "Memory", right_memo: "Memory", success_prob: float = 1):
+    def __init__(self, owner: Node, name: str, left_memo: Memory, right_memo: Memory, success_prob: float = 1):
         """Constructor for Entanglement Swapping A protocol.
 
         Args:
@@ -138,7 +150,7 @@ class EntanglementSwappingA(EntanglementProtocol, ABC):
         return decorator
 
     @classmethod
-    def create(cls, owner: "Node", name: str, left_memo: "Memory", right_memo: "Memory", 
+    def create(cls, owner: Node, name: str, left_memo: Memory, right_memo: Memory, 
                success_prob: float = 1, **kwargs) -> 'EntanglementSwappingA':
         """Factory method to create an Entanglement Swapping A protocol instance of the global formalism.
 
@@ -215,7 +227,7 @@ class EntanglementSwappingA(EntanglementProtocol, ABC):
         """
         raise Exception("EntanglementSwappingA protocol '{}' should not receive messages.".format(self.name))
 
-    def memory_expire(self, memory: "Memory") -> None:
+    def memory_expire(self, memory: Memory) -> None:
         """Method to receive memory expiration events.
 
         Releases held memories on current node.
@@ -259,7 +271,7 @@ class EntanglementSwappingB(EntanglementProtocol, ABC):
     _registry: dict[str, type['EntanglementSwappingB']] = {}
     _global_formalism: str = KET_VECTOR_FORMALISM
 
-    def __init__(self, owner: "Node", name: str, hold_memo: "Memory"):
+    def __init__(self, owner: Node, name: str, hold_memo: Memory):
         """Constructor for entanglement swapping B protocol.
 
         Args:
@@ -326,7 +338,7 @@ class EntanglementSwappingB(EntanglementProtocol, ABC):
         return decorator
 
     @classmethod
-    def create(cls, owner: "Node", name: str, hold_memo: "Memory", **kwargs) -> 'EntanglementSwappingB':
+    def create(cls, owner: Node, name: str, hold_memo: Memory, **kwargs) -> 'EntanglementSwappingB':
         """Factory method to create an Entanglement Swapping B protocol instance of the global formalism.
         """
         protocol_name = EntanglementSwappingB.get_formalism()

--- a/sequence/entanglement_management/swapping/swapping_base.py
+++ b/sequence/entanglement_management/swapping/swapping_base.py
@@ -1,0 +1,379 @@
+"""The base class for entanglement swapping protocol.
+"""
+from __future__ import annotations
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+from enum import Enum, auto
+from typing import TYPE_CHECKING
+
+from ..entanglement_protocol import EntanglementProtocol
+from ...constants import KET_VECTOR_FORMALISM
+from ...message import Message
+from ...utils import log
+
+if TYPE_CHECKING:
+    from ...components.memory import Memory
+    from ...topology.node import Node
+
+
+class SwappingMsgType(Enum):
+    """Defines possible message types for entanglement generation.
+    """
+    SWAP_RES = auto()
+
+
+class EntanglementSwappingMessage(Message):
+    """Message used by entanglement swapping protocols.
+
+    This message contains all information passed between swapping protocol instances.
+
+    Attributes:
+        msg_type (SwappingMsgType): defines the message type.
+        receiver (str): name of destination protocol instance.
+        fidelity (float): fidelity of the newly swapped memory pair.
+        remote_node (str): name of the distant node holding the entangled memory of the new pair.
+        remote_memo (int): index of the entangled memory on the remote node.
+        expire_time (int): expiration time of the new memory pair.
+    """
+
+    def __init__(self, msg_type: SwappingMsgType, receiver: str, **kwargs):
+        Message.__init__(self, msg_type, receiver)
+        if self.msg_type is SwappingMsgType.SWAP_RES:
+            self.fidelity = kwargs.get("fidelity")
+            self.remote_node = kwargs.get("remote_node")
+            self.remote_memo = kwargs.get("remote_memo")
+            self.expire_time = kwargs.get("expire_time")
+            self.meas_res = kwargs.get("meas_res")
+        else:
+            raise Exception("Entanglement swapping protocol create unkown type of message: %s" % str(msg_type))
+
+    def __str__(self):
+        if self.msg_type == SwappingMsgType.SWAP_RES:
+            return "EntanglementSwappingMessage: msg_type: {}; fidelity: {:.2f}; remote_node: {}; remote_memo: {}; ".format(
+                self.msg_type, self.fidelity, self.remote_node, self.remote_memo)
+
+
+class EntanglementSwappingA(EntanglementProtocol, ABC):
+    """Base class for Entanglement Swapping A protocol.
+
+        The default formalism is KET_VECTOR_FORMALISM.
+    """
+    _registry: dict[str, type['EntanglementSwappingA']] = {}
+    _global_formalism: str = KET_VECTOR_FORMALISM
+
+    def __init__(self, owner: "Node", name: str, left_memo: "Memory", right_memo: "Memory", success_prob: float = 1):
+        """Constructor for Entanglement Swapping A protocol.
+
+        Args:
+            owner (Node): node that protocol instance is attached to.
+            name (str): label for protocol instance.
+            left_memo (Memory): memory entangled with a memory on one distant node.
+            right_memo (Memory): memory entangled with a memory on the other distant node.
+            success_prob (float): probability of a successful swapping operation (default 1).
+        """
+        assert left_memo != right_memo
+        super().__init__(owner, name, 'EntanglementSwappingA')
+        self.memories = [left_memo, right_memo]
+        self.left_memo = left_memo
+        self.right_memo = right_memo
+        self.left_node = left_memo.entangled_memory['node_id']
+        self.left_remote_memo = left_memo.entangled_memory['memo_id']
+        self.right_node = right_memo.entangled_memory['node_id']
+        self.right_remote_memo = right_memo.entangled_memory['memo_id']
+        self.success_prob = success_prob
+        assert 1 >= self.success_prob >= 0, "Entanglement swapping success probability must be between 0 and 1."
+        self.is_success = False
+        self.left_protocol_name = None
+        self.right_protocol_name = None
+
+    @classmethod
+    def set_formalism(cls, formalism: str) -> None:
+        """Set the global formalism for all Entanglement Swapping A protocol instances.
+
+        Args:
+            formalism (str): global formalism for all Entanglement Swapping A protocol instances.
+        """
+        if formalism not in cls._registry:
+            raise ValueError(f"Protocol type {formalism} not found in registry.")
+        cls._global_formalism = formalism
+
+    @classmethod
+    def get_formalism(cls) -> str:
+        """Get the global formalism for all Entanglement Swapping A protocol instances.
+
+        Returns:
+            The global formalism for all Entanglement Swapping A protocol instances.
+        """
+        return cls._global_formalism
+
+    @classmethod
+    def register(cls, name: str, protocol_class: type['EntanglementSwappingA'] = None
+                 ) -> Callable[[type['EntanglementSwappingA']], type['EntanglementSwappingA']] | None:
+        """Register a specific type of Entanglement Swapping A protocol.
+
+        This method should be used as a decorator to register different types of Entanglement Swapping A protocols.
+        The registered protocol can then be set as the global formalism for all Entanglement Swapping A protocol instances.
+
+        Args:
+            name (str): name of the specific type of Entanglement Swapping A protocol.
+            protocol_class (type[EntanglementSwappingA] | None): the class of the specific type of Entanglement Swapping A protocol. If None, the decorated class will be registered.
+
+        Returns:
+            If protocol_class is None, returns a decorator function. Otherwise, returns None.
+        """
+        if name in cls._registry:
+            raise ValueError(f"Protocol type {name} already registered.")
+
+        if protocol_class is not None:
+            cls._registry[name] = protocol_class
+            return None
+
+        def decorator(protocol_class: type['EntanglementSwappingA']) -> type['EntanglementSwappingA']:
+            if name in cls._registry:
+                raise ValueError(f"Protocol type {name} already registered.")
+            cls._registry[name] = protocol_class
+            return protocol_class
+        
+        return decorator
+
+    @classmethod
+    def create(cls, owner: "Node", name: str, left_memo: "Memory", right_memo: "Memory", 
+               success_prob: float = 1, **kwargs) -> 'EntanglementSwappingA':
+        """Factory method to create an Entanglement Swapping A protocol instance of the global formalism.
+
+        Args:
+            owner (Node): node that protocol instance is attached to.
+            name (str): label for protocol instance.
+            left_memo (Memory): memory entangled with a memory on one distant node.
+            right_memo (Memory): memory entangled with a memory on the other distant node.
+            success_prob (float): probability of a successful swapping operation (default 1).
+
+        Returns:
+            An instance of the Entanglement Swapping A protocol of the global formalism.
+        """
+        protocol_name = EntanglementSwappingA.get_formalism()
+        try:
+            protocol_class = cls._registry[protocol_name]
+            return protocol_class(owner, name, left_memo, right_memo, success_prob, **kwargs)
+        except KeyError:
+            raise ValueError(f"Protocol class '{protocol_name}' is not registered.")
+
+    @classmethod
+    def list_protocols(cls) -> list[str]:
+        """List all registered Entanglement Swapping A protocols.
+
+        Returns:
+            A list of names of all registered Entanglement Swapping A protocols.
+        """
+        return list(cls._registry.keys())
+
+    @classmethod
+    def clear_global_formalism(cls) -> None:
+        """Resets the global formalism to default"""
+        cls._global_formalism = KET_VECTOR_FORMALISM
+
+    def is_ready(self) -> bool:
+        """Check if the protocol is ready.
+        
+        Returns:
+            bool: True if the protocol is ready to start, False otherwise.
+        """
+        return (self.left_protocol_name is not None) and (self.right_protocol_name is not None)
+    
+    def set_others(self, protocol: str, node: str, memories: list[str]) -> None:
+        """Method to set other entanglement protocol instance.
+
+        Args:
+            protocol (str): other protocol name.
+            node (str): other node name.
+            memories (list[str]): the list of memories name used on other node.
+        """
+        if node == self.left_memo.entangled_memory["node_id"]:
+            self.left_protocol_name = protocol
+        elif node == self.right_memo.entangled_memory["node_id"]:
+            self.right_protocol_name = protocol
+        else:
+            raise Exception("Cannot pair protocol %s with %s" % (self.name, protocol))
+
+    def success_probability(self) -> float:
+        """A simple model for BSM success probability.
+
+        Returns:             
+            float: the probability of a successful swapping operation.
+        """
+        return self.success_prob
+
+    @abstractmethod
+    def start(self) -> None:
+        """Method to start entanglement swapping process (abstract).
+        """
+        pass
+
+    def received_message(self, src: str, msg: Message) -> None:
+        """Method to receive messages (should not be used on A protocol).
+        """
+        raise Exception("EntanglementSwappingA protocol '{}' should not receive messages.".format(self.name))
+
+    def memory_expire(self, memory: "Memory") -> None:
+        """Method to receive memory expiration events.
+
+        Releases held memories on current node.
+        Memories at the remote node are released as well.
+
+        Args:
+            memory (Memory): memory that expired.
+
+        Side Effects:
+            Will invoke `update` method of attached resource manager.
+            Will invoke `release_remote_protocol` or `release_remote_memory` method of resource manager.
+        """
+        assert self.is_ready() is False
+        if self.left_protocol_name:
+            self.release_remote_protocol(self.left_node)
+        else:
+            self.release_remote_memory(self.left_node, self.left_remote_memo)
+        if self.right_protocol_name:
+            self.release_remote_protocol(self.right_node)
+        else:
+            self.release_remote_memory(self.right_node, self.right_remote_memo)
+
+        for memo in self.memories:
+            if memo == memory:
+                self.update_resource_manager(memo, "RAW")
+            else:
+                self.update_resource_manager(memo, "ENTANGLED")
+
+    def release_remote_protocol(self, remote_node: str):
+        self.owner.resource_manager.release_remote_protocol(remote_node, self)
+
+    def release_remote_memory(self, remote_node: str, remote_memo: str):
+        self.owner.resource_manager.release_remote_memory(remote_node, remote_memo)
+
+
+class EntanglementSwappingB(EntanglementProtocol, ABC):
+    """Base class for Entanglement Swapping B protocol.
+
+        The default formalism is KET_VECTOR_FORMALISM.
+    """
+    _registry: dict[str, type['EntanglementSwappingB']] = {}
+    _global_formalism: str = KET_VECTOR_FORMALISM
+
+    def __init__(self, owner: "Node", name: str, hold_memo: "Memory"):
+        """Constructor for entanglement swapping B protocol.
+
+        Args:
+            owner (Node): node protocol instance is attached to.
+            name (str): name of protocol instance.
+            hold_memo (Memory): memory entangled with a memory on middle node.
+        """
+        super().__init__(owner, name, 'EntanglementSwappingB')
+        self.memories = [hold_memo]
+        self.memory = hold_memo
+        self.remote_protocol_name = None
+        self.remote_node_name = None
+
+    @classmethod
+    def set_formalism(cls, formalism: str) -> None:
+        """Set the global formalism for all Entanglement Swapping B protocol instances.
+        
+        Valid Built-formalisms:
+            1. Bell Diagonal -> bds
+            2. Circuit -> circuit (DEFAULT)
+
+        Args:
+            formalism (str): global formalism for all Entanglement Swapping B protocol instances.
+        """
+        if formalism not in cls._registry:
+            raise ValueError(f"Protocol type {formalism} not found in registry.")
+        cls._global_formalism = formalism
+
+    @classmethod
+    def get_formalism(cls) -> str:
+        """Get the global formalism for all Entanglement Swapping B protocol instances.
+
+        Returns:
+            The global formalism for all Entanglement Swapping B protocol instances.
+        """
+        return cls._global_formalism
+
+    @classmethod
+    def register(cls, name: str, protocol_class: type['EntanglementSwappingB'] = None
+                 ) -> Callable[[type['EntanglementSwappingB']], type['EntanglementSwappingB']] | None:
+        """Register a specific type of Entanglement Swapping B protocol.
+
+        This method should be used as a decorator to register different types of Entanglement Swapping B protocols.
+
+        Args:
+            name (str): name of the specific type of Entanglement Swapping B protocol.
+            protocol_class (type[EntanglementSwappingB] | None): the class of the specific type of Entanglement Swapping B protocol. If None, the decorated class will be registered.
+
+        Returns:
+            If protocol_class is None, returns a decorator function. Otherwise, returns None.
+        """
+        if name in cls._registry:
+            raise ValueError(f"{name} already registered.")
+
+        if protocol_class is not None:
+            cls._registry[name] = protocol_class
+        
+        def decorator(protocol_class: type['EntanglementSwappingB']) -> type['EntanglementSwappingB']:
+            if name in cls._registry:
+                raise ValueError(f"{name} already registered.")
+            cls._registry[name] = protocol_class
+            return protocol_class
+
+        return decorator
+
+    @classmethod
+    def create(cls, owner: "Node", name: str, hold_memo: "Memory", **kwargs) -> 'EntanglementSwappingB':
+        """Factory method to create an Entanglement Swapping B protocol instance of the global formalism.
+        """
+        protocol_name = EntanglementSwappingB.get_formalism()
+        try:
+            protocol_class = cls._registry[protocol_name]
+            return protocol_class(owner, name, hold_memo, **kwargs)
+        except KeyError:
+            raise ValueError(f"Protocol class '{protocol_name}' is not registered.")
+
+    def is_ready(self) -> bool:
+        return self.remote_protocol_name is not None
+
+    def set_others(self, protocol: str, node: str, memories: list[str]) -> None:
+        """Method to set other entanglement protocol instance.
+
+        Args:
+            protocol (str): other protocol name.
+            node (str): other node name.
+            memories (list[str]): the list of memory names used on other node.
+        """
+        self.remote_node_name = node
+        self.remote_protocol_name = protocol
+
+    def start(self) -> None:
+        log.logger.info(f"{self.owner.name} end protocol start with partner {self.remote_node_name}")
+
+    def memory_expire(self, memory: Memory) -> None:
+        """Method to deal with expired memories.
+
+        Args:
+            memory (Memory): memory that expired.
+
+        Side Effects:
+            Will update memory in attached resource manager.
+        """
+
+        self.update_resource_manager(self.memory, "RAW")
+
+    def release(self) -> None:
+        self.update_resource_manager(self.memory, "ENTANGLED")
+
+    @abstractmethod
+    def received_message(self, src: str, msg: EntanglementSwappingMessage) -> None:
+        """Method to receive messages from EntanglementSwappingA.
+
+        Args:
+            src (str): name of node sending message.
+            msg (EntanglementSwappingMessage): message sent.
+        """
+        pass
+

--- a/sequence/entanglement_management/swapping/swapping_bds.py
+++ b/sequence/entanglement_management/swapping/swapping_bds.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+from .swapping_base import EntanglementSwappingA, EntanglementSwappingB, SwappingMsgType, EntanglementSwappingMessage
+from ...utils import log
+from ...kernel.quantum_manager import BELL_DIAGONAL_STATE_FORMALISM
+
+if TYPE_CHECKING:
+    from ...components.memory import Memory
+    from ...topology.node import Node
+
+
+@EntanglementSwappingA.register(BELL_DIAGONAL_STATE_FORMALISM)
+class EntanglementSwappingA_BDS(EntanglementSwappingA):
+    """Entanglement swapping protocol for middle node/router.
+
+    The entanglement swapping protocol is an asymmetric protocol.
+    EntanglementSwappingA should be instantiated on the middle node,
+        where it measures a memory from each pair to be swapped.
+    Results of measurement and swapping are sent to the end nodes.
+
+    Variables:
+        EntanglementSwappingA.circuit (Circuit): circuit that does swapping operations.
+
+    Attributes:
+        owner (Node): node that protocol instance is attached to.
+        name (str): label for protocol instance.
+        left_memo (Memory): a memory from one pair to be swapped.
+        right_memo (Memory): a memory from the other pair to be swapped.
+        left_node (str): name of node that contains memory entangling with left_memo.
+        left_remote_memo (str): name of memory that entangles with left_memo.
+        right_node (str): name of node that contains memory entangling with right_memo.
+        right_remote_memo (str): name of memory that entangles with right_memo.
+        success_prob (float): probability of a successful swapping operation.
+        is_success (bool): flag to show the result of swapping.
+        left_protocol_name (str): name of left protocol.
+        right_protocol_name (str): name of right protocol.
+        is_twirled (bool): whether the input and output states are twirled into Werner form (default True).
+    """
+
+    def __init__(self, owner: "Node", name: str, left_memo: "Memory", right_memo: "Memory", success_prob=1, is_twirled=True):
+        """Constructor for entanglement swapping A protocol.
+
+        Args:
+            owner (Node): node that protocol instance is attached to.
+            name (str): label for swapping protocol instance.
+            left_memo (Memory): memory entangled with a memory on one distant node.
+            right_memo (Memory): memory entangled with a memory on the other distant node.
+            success_prob (float): probability of a successful swapping operation (default 1).
+            is_twirled (bool): whether the input and output states are twirled into Werner form (default True).
+        """
+        assert left_memo != right_memo
+        super().__init__(owner, name, left_memo, right_memo, success_prob)
+        self.is_twirled = is_twirled
+
+    def start(self) -> None:
+        """Method to start entanglement swapping protocol.
+
+        Will run circuit and send measurement results to other protocols.
+
+        Side Effects:
+            Will call `update_resource_manager` method.
+            Will send messages to other protocols.
+        """
+
+        log.logger.info(f"{self.owner.name} middle protocol start with ends {self.left_protocol_name}, {self.right_protocol_name}")
+
+        assert self.left_memo.fidelity > 0 and self.right_memo.fidelity > 0
+        assert self.left_memo.entangled_memory["node_id"] == self.left_node
+        assert self.right_memo.entangled_memory["node_id"] == self.right_node
+
+        if self.owner.get_generator().random() < self.success_probability():
+            log.logger.debug(f'swapping successed!')
+            self.is_success = True
+            expire_time = min(self.left_memo.get_expire_time(), self.right_memo.get_expire_time())
+            # first invoke single-memory decoherence channels on each involved quantum memory (in total 4)
+            # note that bds_decohere() has changed the last_update_time to now, 
+            # thus we don't need to change it for the udpated state from swapping
+            left_remote_memory: Memory = self.owner.timeline.get_entity_by_name(self.left_remote_memo)
+            right_remote_memory: Memory = self.owner.timeline.get_entity_by_name(self.right_remote_memo)
+            self.left_memo.bds_decohere()
+            left_remote_memory.bds_decohere()
+            self.right_memo.bds_decohere()
+            right_remote_memory.bds_decohere()
+            # get BDS conditioned on success, fidelity is the first diagonal element
+            new_bds = self.swapping_res()
+            fidelity = new_bds[0]
+            keys = [left_remote_memory.qstate_key, right_remote_memory.qstate_key]
+            self.owner.timeline.quantum_manager.set(keys, new_bds)
+
+            msg_l = EntanglementSwappingMessage(SwappingMsgType.SWAP_RES,
+                                                self.left_protocol_name,
+                                                fidelity=fidelity,
+                                                remote_node=self.right_memo.entangled_memory["node_id"],
+                                                remote_memo=self.right_memo.entangled_memory["memo_id"],
+                                                expire_time=expire_time,
+                                                meas_res=[])
+            msg_r = EntanglementSwappingMessage(SwappingMsgType.SWAP_RES,
+                                                self.right_protocol_name,
+                                                fidelity=fidelity,
+                                                remote_node=self.left_memo.entangled_memory["node_id"],
+                                                remote_memo=self.left_memo.entangled_memory["memo_id"],
+                                                expire_time=expire_time,
+                                                meas_res=[])
+        else:
+            log.logger.debug(f'swapping failed!')
+            msg_l = EntanglementSwappingMessage(SwappingMsgType.SWAP_RES, self.left_protocol_name, fidelity=0)
+            msg_r = EntanglementSwappingMessage(SwappingMsgType.SWAP_RES, self.right_protocol_name, fidelity=0)
+
+        self.owner.send_message(self.left_node, msg_l)
+        self.owner.send_message(self.right_node, msg_r)
+
+        self.update_resource_manager(self.left_memo, "RAW")
+        self.update_resource_manager(self.right_memo, "RAW")
+
+    def swapping_res(self) -> list[float]:
+        """Method to calculate the resulting entangled state conditioned on successful swapping, for BDS formalism.
+
+        Returns:
+            list[float]: resultant bell diagonal state entries.
+        """
+        assert self.owner.timeline.quantum_manager.get_active_formalism() == BELL_DIAGONAL_STATE_FORMALISM, (
+            "Input states should be Bell diagonal states.")
+
+        left_state = self.owner.timeline.quantum_manager.get(self.left_memo.qstate_key)
+        right_state = self.owner.timeline.quantum_manager.get(self.right_memo.qstate_key)
+
+        left_elem_1, left_elem_2, left_elem_3, left_elem_4 = left_state.state  # BDS diagonal elements of left pair
+        right_elem_1, right_elem_2, right_elem_3, right_elem_4 = right_state.state  # BDS diagonal elements of right pair
+
+        if self.is_twirled:
+            left_elem_2, left_elem_3, left_elem_4 = [(1-left_elem_1)/3] * 3
+            right_elem_2, right_elem_3, right_elem_4 = [(1-right_elem_1)/3] * 3
+
+        # assert 1. >= left_elem_1 >= 0.5 and 1. >= right_elem_1 >= 0.5, "Input states should have fidelity above 1/2."
+        # gate and measurment fidelities on swapping node, assuming two single-qubit measurements have equal fidelity
+        gate_fid, meas_fid = self.owner.gate_fid, self.owner.meas_fid
+        # calculate the BDS elements
+        c_I = left_elem_1 * right_elem_1 + left_elem_2 * right_elem_2 + left_elem_3 * right_elem_3 + left_elem_4 * right_elem_4
+        c_X = left_elem_1 * right_elem_2 + left_elem_2 * right_elem_1 + left_elem_3 * right_elem_4 + left_elem_4 * right_elem_3
+        c_Y = left_elem_1 * right_elem_4 + left_elem_4 * right_elem_1 + left_elem_2 * right_elem_3 + left_elem_3 * right_elem_2
+        c_Z = left_elem_1 * right_elem_3 + left_elem_3 * right_elem_1 + left_elem_2 * right_elem_4 + left_elem_4 * right_elem_2
+
+        new_elem_1 = gate_fid * (meas_fid**2 * c_I + meas_fid*(1-meas_fid)*(c_X+c_Z) + (1-meas_fid)**2*c_Y) + (1-gate_fid)/4
+        new_elem_2 = gate_fid * (meas_fid**2 * c_X + meas_fid*(1-meas_fid)*(c_I+c_Y) + (1-meas_fid)**2*c_Z) + (1-gate_fid)/4
+        new_elem_3 = gate_fid * (meas_fid**2 * c_Z + meas_fid*(1-meas_fid)*(c_I+c_Y) + (1-meas_fid)**2*c_X) + (1-gate_fid)/4
+        new_elem_4 = gate_fid * (meas_fid**2 * c_Y + meas_fid*(1-meas_fid)*(c_X+c_Z) + (1-meas_fid)**2*c_I) + (1-gate_fid)/4        
+
+        if self.is_twirled:
+            bds_elems = [new_elem_1, (1-new_elem_1)/3, (1-new_elem_1)/3, (1-new_elem_1)/3]
+        else:
+            bds_elems = [new_elem_1, new_elem_2, new_elem_3, new_elem_4]
+        
+        log.logger.debug(f'before swapping, f = {left_state.state[0]:.6f}, {right_state.state[0]:.6f}; after swapping, f = {bds_elems[0]:.6f}')
+
+        return bds_elems
+
+
+@EntanglementSwappingB.register(BELL_DIAGONAL_STATE_FORMALISM)
+class EntanglementSwappingB_BDS(EntanglementSwappingB):
+    """Entanglement swapping protocol for end node/router.
+
+    The entanglement swapping protocol is an asymmetric protocol.
+    EntanglementSwappingB should be instantiated on the end nodes, where it waits for swapping results from the middle node.
+
+    Variables:
+        EntanglementSwappingB.x_cir (Circuit): circuit that corrects state with an x gate.
+        EntanglementSwappingB.z_cir (Circuit): circuit that corrects state with z gate.
+        EntanglementSwappingB.x_z_cir (Circuit): circuit that corrects state with an x and z gate.
+
+    Attributes:
+        own (QuantumRouter): node that protocol instance is attached to.
+        name (str): name of protocol instance.
+        memory (Memory): memory to swap.
+        remote_protocol_name (str): name of another protocol to communicate with for swapping.
+        remote_node_name (str): name of node hosting the other protocol.
+    """
+
+    def __init__(self, own: Node, name: str, hold_memo: Memory):
+        """Constructor for entanglement swapping B protocol.
+
+        Args:
+            owner (Node): node protocol instance is attached to.
+            name (str): name of protocol instance.
+            hold_memo (Memory): memory entangled with a memory on middle node.
+        """
+        super().__init__(own, name, hold_memo)
+
+    def received_message(self, src: str, msg: EntanglementSwappingMessage) -> None:
+        """Method to receive messages from EntanglementSwappingA.
+
+        Args:
+            src (str): name of node sending message.
+            msg (EntanglementSwappingMessage): message sent.
+
+        Side Effects:
+            Will invoke `update_resource_manager` method.
+        """
+
+        log.logger.debug(self.owner.name + " protocol received_message from node {}, fidelity={:.6f}".format(src, msg.fidelity))
+
+        assert src == self.remote_node_name
+
+        if msg.fidelity > 0 and self.owner.timeline.now() < msg.expire_time:
+            # if using BDS formalism, updated BDS has been determined analytically taking into account local correction, 
+            self.memory.entangled_memory["node_id"] = msg.remote_node
+            self.memory.entangled_memory["memo_id"] = msg.remote_memo
+            remote_memory: Memory = self.owner.timeline.get_entity_by_name(msg.remote_memo)
+            self.memory.bds_decohere()
+            remote_memory.bds_decohere()
+            self.memory.fidelity = self.memory.get_bds_fidelity()
+            self.memory.update_expire_time(msg.expire_time)
+            self.update_resource_manager(self.memory, "ENTANGLED")
+        else:
+            self.update_resource_manager(self.memory, "RAW")

--- a/sequence/entanglement_management/swapping/swapping_bds.py
+++ b/sequence/entanglement_management/swapping/swapping_bds.py
@@ -1,3 +1,5 @@
+"""The entanglement swapping protocol for Bell Diagonal State (BDS) formalism.
+"""
 from __future__ import annotations
 from typing import TYPE_CHECKING
 
@@ -39,7 +41,7 @@ class EntanglementSwappingA_BDS(EntanglementSwappingA):
         is_twirled (bool): whether the input and output states are twirled into Werner form (default True).
     """
 
-    def __init__(self, owner: "Node", name: str, left_memo: "Memory", right_memo: "Memory", success_prob=1, is_twirled=True):
+    def __init__(self, owner: Node, name: str, left_memo: Memory, right_memo: Memory, success_prob=1, is_twirled=True):
         """Constructor for entanglement swapping A protocol.
 
         Args:

--- a/sequence/entanglement_management/swapping/swapping_bds.py
+++ b/sequence/entanglement_management/swapping/swapping_bds.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 from .swapping_base import EntanglementSwappingA, EntanglementSwappingB, SwappingMsgType, EntanglementSwappingMessage
 from ...utils import log
 from ...kernel.quantum_manager import BELL_DIAGONAL_STATE_FORMALISM
+from ...resource_management.memory_manager import MemoryInfo
 
 if TYPE_CHECKING:
     from ...components.memory import Memory
@@ -110,8 +111,8 @@ class EntanglementSwappingA_BDS(EntanglementSwappingA):
         self.owner.send_message(self.left_node, msg_l)
         self.owner.send_message(self.right_node, msg_r)
 
-        self.update_resource_manager(self.left_memo, "RAW")
-        self.update_resource_manager(self.right_memo, "RAW")
+        self.update_resource_manager(self.left_memo, MemoryInfo.RAW)
+        self.update_resource_manager(self.right_memo, MemoryInfo.RAW)
 
     def swapping_res(self) -> list[float]:
         """Method to calculate the resulting entangled state conditioned on successful swapping, for BDS formalism.
@@ -202,7 +203,7 @@ class EntanglementSwappingB_BDS(EntanglementSwappingB):
         assert src == self.remote_node_name
 
         if msg.fidelity > 0 and self.owner.timeline.now() < msg.expire_time:
-            # if using BDS formalism, updated BDS has been determined analytically taking into account local correction, 
+            # if using BDS formalism, updated BDS has been determined analytically taking into account local correction
             self.memory.entangled_memory["node_id"] = msg.remote_node
             self.memory.entangled_memory["memo_id"] = msg.remote_memo
             remote_memory: Memory = self.owner.timeline.get_entity_by_name(msg.remote_memo)
@@ -210,6 +211,6 @@ class EntanglementSwappingB_BDS(EntanglementSwappingB):
             remote_memory.bds_decohere()
             self.memory.fidelity = self.memory.get_bds_fidelity()
             self.memory.update_expire_time(msg.expire_time)
-            self.update_resource_manager(self.memory, "ENTANGLED")
+            self.update_resource_manager(self.memory, MemoryInfo.ENTANGLED)
         else:
-            self.update_resource_manager(self.memory, "RAW")
+            self.update_resource_manager(self.memory, MemoryInfo.RAW)

--- a/sequence/entanglement_management/swapping/swapping_circuit.py
+++ b/sequence/entanglement_management/swapping/swapping_circuit.py
@@ -1,16 +1,5 @@
-"""Code for entanglement swapping.
-
-This module defines code for entanglement swapping.
-Success is pre-determined based on network parameters.
-The entanglement swapping protocol is an asymmetric protocol:
-
-* The EntanglementSwappingA instance initiates the protocol and performs the swapping operation.
-* The EntanglementSwappingB instance waits for the swapping result from EntanglementSwappingA.
-
-The swapping results decides the following operations of EntanglementSwappingB.
-Also defined in this module is the message type used by these protocols.
+"""The entanglement swapping protocol for circuit-based (ket vector, density matrix) formalism.
 """
-
 
 from __future__ import annotations
 from typing import TYPE_CHECKING
@@ -174,7 +163,7 @@ class EntanglementSwappingB_Circuit(EntanglementSwappingB):
     x_z_cir.x(0)
     x_z_cir.z(0)
 
-    def __init__(self, owner: "Node", name: str, hold_memo: "Memory"):
+    def __init__(self, owner: Node, name: str, hold_memo: Memory):
         """Constructor for entanglement swapping B protocol.
 
         Args:

--- a/sequence/entanglement_management/swapping/swapping_circuit.py
+++ b/sequence/entanglement_management/swapping/swapping_circuit.py
@@ -11,69 +11,36 @@ The swapping results decides the following operations of EntanglementSwappingB.
 Also defined in this module is the message type used by these protocols.
 """
 
-from enum import Enum, auto
+
+from __future__ import annotations
 from typing import TYPE_CHECKING
 from functools import lru_cache
 
 if TYPE_CHECKING:
-    from ..components.memory import Memory
-    from ..topology.node import Node
+    from ...components.memory import Memory
+    from ...topology.node import Node
 
-from ..message import Message
-from .entanglement_protocol import EntanglementProtocol
-from ..utils import log
-from ..components.circuit import Circuit
-from ..resource_management.memory_manager import MemoryInfo
-
-class SwappingMsgType(Enum):
-    """Defines possible message types for entanglement generation."""
-
-    SWAP_RES = auto()
+from .swapping_base import EntanglementSwappingA, EntanglementSwappingB, SwappingMsgType, EntanglementSwappingMessage
+from ...components.circuit import Circuit
+from ...constants import KET_VECTOR_FORMALISM, DENSITY_MATRIX_FORMALISM
+from ...resource_management.memory_manager import MemoryInfo
+from ...utils import log
 
 
-class EntanglementSwappingMessage(Message):
-    """Message used by entanglement swapping protocols.
-
-    This message contains all information passed between swapping protocol instances.
-
-    Attributes:
-        msg_type (SwappingMsgType): defines the message type.
-        receiver (str): name of destination protocol instance.
-        fidelity (float): fidelity of the newly swapped memory pair.
-        remote_node (str): name of the distant node holding the entangled memory of the new pair.
-        remote_memo (int): index of the entangled memory on the remote node.
-        expire_time (int): expiration time of the new memory pair.
-    """
-
-    def __init__(self, msg_type: SwappingMsgType, receiver: str, **kwargs):
-        Message.__init__(self, msg_type, receiver)
-        if self.msg_type is SwappingMsgType.SWAP_RES:
-            self.fidelity = kwargs.get("fidelity")
-            self.remote_node = kwargs.get("remote_node")
-            self.remote_memo = kwargs.get("remote_memo")
-            self.expire_time = kwargs.get("expire_time")
-            self.meas_res = kwargs.get("meas_res")
-        else:
-            raise Exception("Entanglement swapping protocol create unkown type of message: %s" % str(msg_type))
-
-    def __str__(self):
-        if self.msg_type == SwappingMsgType.SWAP_RES:
-            return "EntanglementSwappingMessage: msg_type: {}; fidelity: {:.2f}; remote_node: {}; remote_memo: {}; ".format(
-                self.msg_type, self.fidelity, self.remote_node, self.remote_memo)
-
-
-class EntanglementSwappingA(EntanglementProtocol):
+@EntanglementSwappingA.register(KET_VECTOR_FORMALISM)
+@EntanglementSwappingA.register(DENSITY_MATRIX_FORMALISM)
+class EntanglementSwappingA_Circuit(EntanglementSwappingA):
     """Entanglement swapping protocol for middle router.
 
     The entanglement swapping protocol is an asymmetric protocol.
-    EntanglementSwappingA should be instantiated on the middle node, where it measures a memory from each pair to be swapped.
+    EntanglementSwappingA_Circuit should be instantiated on the middle node, where it measures a memory from each pair to be swapped.
     Results of measurement and swapping are sent to the end routers.
 
     Variables:
-        EntanglementSwappingA.circuit (Circuit): circuit that does swapping operations.
+        EntanglementSwappingA_Circuit.circuit (Circuit): circuit that does swapping operations.
 
     Attributes:
-        own (Node): node that protocol instance is attached to.
+        owner (Node): node that protocol instance is attached to.
         name (str): label for protocol instance.
         left_memo (Memory): a memory from one pair to be swapped.
         right_memo (Memory): a memory from the other pair to be swapped.
@@ -94,7 +61,7 @@ class EntanglementSwappingA(EntanglementProtocol):
     circuit.measure(0)
     circuit.measure(1)
 
-    def __init__(self, owner: "Node", name: str, left_memo: "Memory", right_memo: "Memory", success_prob=1, degradation=0.95):
+    def __init__(self, owner: Node, name: str, left_memo: Memory, right_memo: Memory, success_prob=1, degradation=0.95):
         """Constructor for entanglement swapping A protocol.
 
         Args:
@@ -105,43 +72,9 @@ class EntanglementSwappingA(EntanglementProtocol):
             success_prob (float): probability of a successful swapping operation (default 1).
             degradation (float): degradation factor of memory fidelity after swapping (default 0.95).
         """
-
         assert left_memo != right_memo
-        EntanglementProtocol.__init__(self, owner, name)
-        self.memories = [left_memo, right_memo]
-        self.left_memo = left_memo
-        self.right_memo = right_memo
-        self.left_node = left_memo.entangled_memory['node_id']
-        self.left_remote_memo = left_memo.entangled_memory['memo_id']
-        self.right_node = right_memo.entangled_memory['node_id']
-        self.right_remote_memo = right_memo.entangled_memory['memo_id']
-        self.success_prob = success_prob
+        super().__init__(owner, name, left_memo, right_memo, success_prob)
         self.degradation = degradation
-        self.is_success = False
-        self.left_protocol_name = None
-        self.right_protocol_name = None
-
-    def is_ready(self) -> bool:
-        """Return True if left_protocol and right_protocol are both set.
-        """
-
-        return (self.left_protocol_name is not None) and (self.right_protocol_name is not None)
-
-    def set_others(self, protocol: str, node: str, memories: list[str]) -> None:
-        """Method to set other entanglement protocol instance.
-
-        Args:
-            protocol (str): other protocol name.
-            node (str): other node name.
-            memories (list[str]): the list of memories name used on other node.
-        """
-
-        if node == self.left_memo.entangled_memory["node_id"]:
-            self.left_protocol_name = protocol
-        elif node == self.right_memo.entangled_memory["node_id"]:
-            self.right_protocol_name = protocol
-        else:
-            raise Exception(f"Cannot pair protocol {self.name} with {protocol}")
 
     def start(self) -> None:
         """Method to start entanglement swapping protocol.
@@ -195,12 +128,6 @@ class EntanglementSwappingA(EntanglementProtocol):
         self.update_resource_manager(self.left_memo, MemoryInfo.RAW)
         self.update_resource_manager(self.right_memo, MemoryInfo.RAW)
 
-
-    def success_probability(self) -> float:
-        """A simple model for BSM success probability."""
-
-        return self.success_prob
-
     @lru_cache(maxsize=128)
     def updated_fidelity(self, f1: float, f2: float) -> float:
         """A simple model updating fidelity of entanglement.
@@ -215,58 +142,19 @@ class EntanglementSwappingA(EntanglementProtocol):
 
         return f1 * f2 * self.degradation
 
-    def received_message(self, src: str, msg: "Message") -> None:
-        """Method to receive messages (should not be used on A protocol)."""
 
-        raise Exception(f"EntanglementSwappingA protocol '{self.name}' should not receive messages.")
-
-    def memory_expire(self, memory: "Memory") -> None:
-        """Method to receive memory expiration events.
-
-        Releases held memories on current node.
-        Memories at the remote node are released as well.
-
-        Args:
-            memory (Memory): memory that expired.
-
-        Side Effects:
-            Will invoke `update` method of attached resource manager.
-            Will invoke `release_remote_protocol` or `release_remote_memory` method of resource manager.
-        """
-
-        assert self.is_ready() is False
-        if self.left_protocol_name:
-            self.release_remote_protocol(self.left_node)
-        else:
-            self.release_remote_memory(self.left_node, self.left_remote_memo)
-        if self.right_protocol_name:
-            self.release_remote_protocol(self.right_node)
-        else:
-            self.release_remote_memory(self.right_node, self.right_remote_memo)
-
-        for memo in self.memories:
-            if memo == memory:
-                self.update_resource_manager(memo, MemoryInfo.RAW)
-            else:
-                self.update_resource_manager(memo, MemoryInfo.ENTANGLED)
-
-    def release_remote_protocol(self, remote_node: str):
-        self.owner.resource_manager.release_remote_protocol(remote_node, self)
-
-    def release_remote_memory(self, remote_node: str, remote_memo: str):
-        self.owner.resource_manager.release_remote_memory(remote_node, remote_memo)
-
-
-class EntanglementSwappingB(EntanglementProtocol):
+@EntanglementSwappingB.register(KET_VECTOR_FORMALISM)
+@EntanglementSwappingB.register(DENSITY_MATRIX_FORMALISM)
+class EntanglementSwappingB_Circuit(EntanglementSwappingB):
     """Entanglement swapping protocol for end router.
 
     The entanglement swapping protocol is an asymmetric protocol.
-    EntanglementSwappingB should be instantiated on the end nodes, where it waits for swapping results from the middle node.
+    EntanglementSwappingB_Circuit should be instantiated on the end nodes, where it waits for swapping results from the middle node.
 
     Variables:
-        EntanglementSwappingB.x_cir (Circuit): circuit that corrects state with an x gate.
-        EntanglementSwappingB.z_cir (Circuit): circuit that corrects state with z gate.
-        EntanglementSwappingB.x_z_cir (Circuit): circuit that corrects state with an x and z gate.
+        EntanglementSwappingB_Circuit.x_cir (Circuit): circuit that corrects state with an x gate.
+        EntanglementSwappingB_Circuit.z_cir (Circuit): circuit that corrects state with z gate.
+        EntanglementSwappingB_Circuit.x_z_cir (Circuit): circuit that corrects state with an x and z gate.
 
     Attributes:
         own (QuantumRouter): node that protocol instance is attached to.
@@ -290,38 +178,18 @@ class EntanglementSwappingB(EntanglementProtocol):
         """Constructor for entanglement swapping B protocol.
 
         Args:
-            own (Node): node protocol instance is attached to.
+            owner (Node): node protocol instance is attached to.
             name (str): name of protocol instance.
             hold_memo (Memory): memory entangled with a memory on middle node.
         """
-
-        EntanglementProtocol.__init__(self, owner, name)
-
-        self.memories = [hold_memo]
-        self.memory = hold_memo
-        self.remote_protocol_name = None
-        self.remote_node_name = None
-
-    def is_ready(self) -> bool:
-        return self.remote_protocol_name is not None
-
-    def set_others(self, protocol: str, node: str, memories: list[str]) -> None:
-        """Method to set other entanglement protocol instance.
-
-        Args:
-            protocol (str): other protocol name.
-            node (str): other node name.
-            memories (list[str]): the list of memory names used on other node.
-        """
-        self.remote_node_name = node
-        self.remote_protocol_name = protocol
+        super().__init__(owner, name, hold_memo)
 
     def received_message(self, src: str, msg: "EntanglementSwappingMessage") -> None:
         """Method to receive messages from EntanglementSwappingA.
 
         Args:
             src (str): name of node sending message.
-            msg (EntanglementSwappingMesssage): message sent.
+            msg (EntanglementSwappingMessage): message sent.
 
         Side Effects:
             Will invoke `update_resource_manager` method.
@@ -346,21 +214,3 @@ class EntanglementSwappingB(EntanglementProtocol):
             self.update_resource_manager(self.memory, MemoryInfo.ENTANGLED)
         else:
             self.update_resource_manager(self.memory, MemoryInfo.RAW)
-
-    def start(self) -> None:
-        log.logger.debug(f"{self.owner.name} end protocol start with partner {self.remote_node_name}")
-
-    def memory_expire(self, memory: "Memory") -> None:
-        """Method to deal with expired memories.
-
-        Args:
-            memory (Memory): memory that expired.
-
-        Side Effects:
-            Will update memory in attached resource manager.
-        """
-
-        self.update_resource_manager(self.memory, MemoryInfo.RAW)
-
-    def release(self) -> None:
-        self.update_resource_manager(self.memory, MemoryInfo.ENTANGLED)

--- a/sequence/kernel/quantum_manager.py
+++ b/sequence/kernel/quantum_manager.py
@@ -25,7 +25,7 @@ from scipy.special import binom
 
 from .quantum_state import KetState, DensityState, BellDiagonalState
 from .quantum_utils import *
-from ..constants import KET_STATE_FORMALISM, DENSITY_MATRIX_FORMALISM, FOCK_DENSITY_MATRIX_FORMALISM, BELL_DIAGONAL_STATE_FORMALISM
+from ..constants import KET_VECTOR_FORMALISM, DENSITY_MATRIX_FORMALISM, FOCK_DENSITY_MATRIX_FORMALISM, BELL_DIAGONAL_STATE_FORMALISM
 
 
 class QuantumManager(ABC):
@@ -46,7 +46,7 @@ class QuantumManager(ABC):
     """
     _registry: dict = {}
     _global_formalism_lock = Lock()
-    _global_formalism: str = KET_STATE_FORMALISM
+    _global_formalism: str = KET_VECTOR_FORMALISM
 
     def __init__(self, truncation: int = 1):
         self.states: dict[int, "State"] = {}
@@ -74,7 +74,7 @@ class QuantumManager(ABC):
     @classmethod
     def clear_active_formalism(cls):
         with cls._global_formalism_lock:
-            cls._global_formalism = KET_STATE_FORMALISM
+            cls._global_formalism = KET_VECTOR_FORMALISM
 
     @classmethod
     def register(cls, name: str, manager_class=None):
@@ -233,7 +233,7 @@ class QuantumManager(ABC):
         self.states = states
 
 
-@QuantumManager.register(KET_STATE_FORMALISM)
+@QuantumManager.register(KET_VECTOR_FORMALISM)
 class QuantumManagerKet(QuantumManager):
     """Class to track and manage quantum states with the ket vector formalism."""
 

--- a/sequence/protocol.py
+++ b/sequence/protocol.py
@@ -16,22 +16,23 @@ class Protocol(ABC):
     """Abstract protocol class for code running on network nodes.
 
     Attributes:
-        own (Node): node protocol is attached to.
+        owner (Node): node protocol is attached to.
         name (str): label for protocol instance.
         protocol_type (str): type of protocol instance (e.g. 'single_heralded').
     """
 
-    def __init__(self, owner: "Node", name: str):
+    def __init__(self, owner: "Node", name: str, protocol_type: str = ""):
         """Constructor for protocol.
 
         Args:
             owner (Node): node protocol is attached to.
             name (str): name of protocol instance.
+            protocol_type (str): type of protocol instance.
         """
 
         self.owner = owner
         self.name = name
-        self.protocol_type = None
+        self.protocol_type = protocol_type
 
     @abstractmethod
     def received_message(self, src: str, msg: "Message"):
@@ -49,7 +50,7 @@ class StackProtocol(Protocol):
     Adds interfaces for push and pop functions.
 
     Attributes:
-        own (Node): node protocol is attached to.
+        owner (Node): node protocol is attached to.
         name (str): label for protocol instance.
         upper_protocols (list[StackProtocol]): Protocols to pop to.
         lower_protocols (list[StackProtocol]): Protocols to push to.
@@ -59,7 +60,7 @@ class StackProtocol(Protocol):
         """Constructor for stack protocol class.
 
         Args:
-            own (Node): node protocol is attached to.
+            owner (Node): node protocol is attached to.
             name (str): name of protocol instance.
         """
 

--- a/sequence/resource_management/action_condition_set.py
+++ b/sequence/resource_management/action_condition_set.py
@@ -344,7 +344,7 @@ def es_rule_action_A(memories_info: list[MemoryInfo], _args: Arguments) -> Actio
     # es_succ_prob = args["es_succ_prob"]
     # es_degradation = args["es_degradation"]
     memories = [info.memory for info in memories_info]
-    protocol = EntanglementSwappingA(TempNode, f"ESA.{memories[0].name}.{memories[1].name}", memories[0], memories[1])
+    protocol = EntanglementSwappingA.create(TempNode, f"ESA.{memories[0].name}.{memories[1].name}", memories[0], memories[1])
     dsts = [info.remote_node for info in memories_info]
     req_funcs: list[RequestFunction | None] = [es_match_func, es_match_func]
     req_args = [{"target_memo": memories_info[0].remote_memo}, {"target_memo": memories_info[1].remote_memo}]
@@ -366,7 +366,7 @@ def es_rule_action_B(memories_info: list[MemoryInfo], _args: Arguments) -> Actio
     """
     memories = [info.memory for info in memories_info]
     memory = memories[0]
-    protocol = EntanglementSwappingB(TempNode, "ESB." + memory.name, memory)
+    protocol = EntanglementSwappingB.create(TempNode, "ESB." + memory.name, memory)
     return protocol, [None], [None], [None]
 
 

--- a/sequence/topology/router_net_topo.py
+++ b/sequence/topology/router_net_topo.py
@@ -6,7 +6,7 @@ from ..network_management.routing_distributed import DistributedRoutingProtocol
 from ..network_management.routing_static import StaticRoutingProtocol
 from .topology import Topology as Topo
 from ..kernel.timeline import Timeline
-from ..kernel.quantum_manager import KET_STATE_FORMALISM, QuantumManager
+from ..kernel.quantum_manager import KET_VECTOR_FORMALISM, QuantumManager
 from .node import BSMNode, QuantumRouter
 from ..constants import SPEED_OF_LIGHT
 
@@ -56,7 +56,7 @@ class RouterNetTopo(Topo):
 
     def _add_timeline(self, config: dict):
         stop_time = config.get(Topo.STOP_TIME, 10 ** 23)
-        formalism = config.get(Topo.FORMALISM, KET_STATE_FORMALISM)
+        formalism = config.get(Topo.FORMALISM, KET_VECTOR_FORMALISM)
         truncation = config.get(Topo.TRUNC, 1)
         QuantumManager.set_global_manager_formalism(formalism)
         self.tl = Timeline(stop_time=stop_time, truncation=truncation)

--- a/tests/entanglement_management/test_swapping.py
+++ b/tests/entanglement_management/test_swapping.py
@@ -81,11 +81,11 @@ def create_scenario(state1, state2, seed_index):
     a1, a2, a3 = nodes
     memo1, memo2, memo3, memo4 = memories
 
-    es1 = EntanglementSwappingB(a1, "a1.ESb0", memo1)
+    es1 = EntanglementSwappingB.create(a1, "a1.ESb0", memo1)
     a1.protocols.append(es1)
-    es2 = EntanglementSwappingA(a2, "a2.ESa0", memo2, memo3)
+    es2 = EntanglementSwappingA.create(a2, "a2.ESa0", memo2, memo3)
     a2.protocols.append(es2)
-    es3 = EntanglementSwappingB(a3, "a3.ESb1", memo4)
+    es3 = EntanglementSwappingB.create(a3, "a3.ESb1", memo4)
     a3.protocols.append(es3)
 
     es1.set_others(es2.name, a2.name, [memo2.name, memo3.name])
@@ -527,11 +527,11 @@ def test_EntanglementSwapping():
         a1, a2, a3 = nodes
         memo1, memo2, memo3, memo4 = memories
 
-        es1 = EntanglementSwappingB(a1, "a1.ESb%d" % i, memo1)
+        es1 = EntanglementSwappingB.create(a1, "a1.ESb%d" % i, memo1)
         a1.protocols.append(es1)
-        es2 = EntanglementSwappingA(a2, "a2.ESa%d" % i, memo2, memo3, success_prob=0.2)
+        es2 = EntanglementSwappingA.create(a2, "a2.ESa%d" % i, memo2, memo3, success_prob=0.2)
         a2.protocols.append(es2)
-        es3 = EntanglementSwappingB(a3, "a3.ESb%d" % i, memo4)
+        es3 = EntanglementSwappingB.create(a3, "a3.ESb%d" % i, memo4)
         a3.protocols.append(es3)
 
         es1.set_others(es2.name, a2.name, [memo2.name, memo3.name])

--- a/tests/topology/test_node.py
+++ b/tests/topology/test_node.py
@@ -141,5 +141,3 @@ def test_ClassicalNode_send_message():
     expect_node2_log = [(CC_DELAY + i, "node1", str(i)) for i in range(MSG_NUM)]
     for actual, expect in zip(node2.log, expect_node2_log):
         assert actual == expect
-
-test_Node_send_message()

--- a/tests/topology/test_node.py
+++ b/tests/topology/test_node.py
@@ -141,3 +141,5 @@ def test_ClassicalNode_send_message():
     expect_node2_log = [(CC_DELAY + i, "node1", str(i)) for i in range(MSG_NUM)]
     for actual, expect in zip(node2.log, expect_node2_log):
         assert actual == expect
+
+test_Node_send_message()

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11, <3.15"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -2508,7 +2508,7 @@ wheels = [
 
 [[package]]
 name = "sequence"
-version = "0.8.5"
+version = "0.8.6"
 source = { editable = "." }
 dependencies = [
     { name = "dash" },


### PR DESCRIPTION
https://github.com/sequence-toolbox/SeQUeNCe/issues/310. Created the `swapping` module that has the following classes. The subclasses use the registry decorator.

1. Base class: `EntanglementSwappingA` & `EntanglementSwappingB`
2. Subclass for ket vector and density matrix: `EntanglementSwappingA_Circuit` & `EntanglementSwappingB_Circuit`
3. Subclass for Bell diagonal state: `EntanglementSwappingA_BDS` & `EntanglementSwappingB_BDS`

Some other updates:
* Renamed the constant `KET_STATE_FORMALISM` to `KET_VECTOR_FORMALISM` in `sequence/constants.py` 
* Update docstrings, including clarifying the docstring for the `schedule_reservation` method in `request_app.py` to specify that it is called by both the initiator and responder when a reservation is approved.
* Some minor refactoring (i.e., removing the quotation marks for the typing)