### PR TITLE
Make init call more general in QuantumRouter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0] - 2026-3-02
 ### Added
+- Add empty init() to Protocol to satisfy class hierarchy.
 - Created project scripts for each config generator.
 - Created the `swapping` module that has the following classes. The subclasses use the registry decorator (factory pattern).
     - Base class: `EntanglementSwappingA` & `EntanglementSwappingB`
@@ -14,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Subclass for Bell diagonal state: `EntanglementSwappingA_BDS` & `EntanglementSwappingB_BDS`
     
 ### Changed
+- Moved routing_protocol init() to network manager.
+- Trigger empty inits for resource and network manager to enable future bootstrapping.
 - Migrated `utils/json_config_generators/` to `sequence/config_generators/`.
 
 ### Removed

--- a/sequence/network_management/network_manager.py
+++ b/sequence/network_management/network_manager.py
@@ -105,6 +105,10 @@ class NetworkManager(ABC):
         else:
             cls._global_type = network_manager_type
 
+    @classmethod
+    def get_global_type(cls):
+        return cls._global_type
+
     @abstractmethod
     def received_message(self, src: str, msg: NetworkManagerMessage):
         """Handle Message received into the NetworkManager."""
@@ -113,6 +117,9 @@ class NetworkManager(ABC):
     @abstractmethod
     def request(self, responder, start_time, end_time, memory_size, target_fidelity, entanglement_number=1, identity=0):
         """Handle Requests from the Application."""
+        pass
+
+    def init(self):
         pass
 
     def push(self, dst: str, msg: NetworkManagerMessage):
@@ -156,6 +163,9 @@ class DistributedNetworkManager(NetworkManager):
     @property
     def forward(self):
         return self.protocol_stack[0]
+
+    def init(self):
+        self.routing_protocol.init()
 
     def get_forwarding_table(self) -> dict[str, str]:
         """Returns the forwarding table.

--- a/sequence/protocol.py
+++ b/sequence/protocol.py
@@ -40,6 +40,9 @@ class Protocol(ABC):
 
         pass
 
+    def init(self):
+        pass
+
     def __str__(self) -> str:
         return self.name
 

--- a/sequence/resource_management/resource_manager.py
+++ b/sequence/resource_management/resource_manager.py
@@ -145,6 +145,9 @@ class ResourceManager:
         self.waiting_protocols = [] # Protocols that are waiting request from remote resource
         self.memory_to_protocol_map = {}
 
+    def init(self):
+        pass
+
     def generate_load_rules(self, path: list[str], reservation: Reservation, timecards: list[MemoryTimeCard], memory_array_name: str):
         """Generate and load rules for a given reservation.
 

--- a/sequence/topology/node.py
+++ b/sequence/topology/node.py
@@ -390,10 +390,11 @@ class QuantumRouter(Node):
         self.down = down
 
     def init(self):
-        """Method to initialize quantum router node.
         """
-        if self.network_manager.routing_protocol is not None:
-            self.network_manager.routing_protocol.init()
+        Method to initialize the managers.
+        """
+        self.resource_manager.init()
+        self.network_manager.init()
 
     def add_bsm_node(self, bsm_name: str, router_name: str):
         """Method to record connected BSM nodes


### PR DESCRIPTION
- Move initialization of routing protocol to the `DistributedNetworkManager`
- Add empty init() to Protocol to satisfy class hierarchy.
- Trigger empty inits for resource and network manager to enable future bootstrapping.
