### PR TITLE
Deprecate Python 3.11 (#287)

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -15,7 +15,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.11"
           - "3.12"
           - "3.13"
           - "3.14"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ These modules can be edited by users to define additional functionality and test
 
 ## Installation
 ### For Users
-SeQUeNCe requires [Python](https://www.python.org/downloads/) 3.11 or later. You can install SeQUeNCe using `pip`:
+SeQUeNCe requires [Python](https://www.python.org/downloads/) 3.12 or later. You can install SeQUeNCe using `pip`:
 ```
 pip install sequence
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,8 @@ maintainers = [
 ]
 description = "Simulator of QUantum Network Communication (SeQUeNCe) is an open-source tool that allows modeling of quantum networks including photonic network components, control protocols, and applications."
 readme = "README.md"
-requires-python = ">=3.11, <3.15"
+requires-python = ">=3.12, <3.15"
 classifiers = [
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14"

--- a/sequence/components/circuit.py
+++ b/sequence/components/circuit.py
@@ -4,7 +4,6 @@ This module introduces the QuantumCircuit class. The qutip library is used to ca
 """
 
 from math import e, pi, sqrt
-from typing import Optional
 
 import numpy as np
 from qutip_qip.circuit import QubitCircuit

--- a/sequence/entanglement_management/generation/generation_message.py
+++ b/sequence/entanglement_management/generation/generation_message.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from enum import auto, Enum
-from typing import Optional
 
 from ...message import Message
 

--- a/sequence/entanglement_management/generation/single_heralded.py
+++ b/sequence/entanglement_management/generation/single_heralded.py
@@ -248,7 +248,7 @@ class SingleHeraldedB(EntanglementGenerationB):
 
         Args:
             bsm (SingleAtomBSM or SingleHeraldedBSM): bsm object calling method.
-            info (Dict[str, any]): information passed from bsm.
+            info (dict[str, any]): information passed from bsm.
         """
         assert bsm.encoding == SINGLE_HERALDED, "SingleHeraldedB should only be used with SingleHeraldedBSM."
         assert info['info_type'] == 'BSM_res'

--- a/sequence/entanglement_management/purification/bbpssw_bds.py
+++ b/sequence/entanglement_management/purification/bbpssw_bds.py
@@ -151,7 +151,7 @@ class BBPSSW_BDS(BBPSSWProtocol):
         The four BDS density matrix elements of kept entangled pair conditioned on successful purification.
 
         Returns:
-            Tuple[float, np.array]: success probability and BDS density matrix elements of kept entangled pair.
+            tuple[float, np.array]: success probability and BDS density matrix elements of kept entangled pair.
         """
 
         assert self.owner.timeline.quantum_manager.get_active_formalism() == BELL_DIAGONAL_STATE_FORMALISM, (

--- a/sequence/entanglement_management/purification/bbpssw_protocol.py
+++ b/sequence/entanglement_management/purification/bbpssw_protocol.py
@@ -96,7 +96,7 @@ class BBPSSWProtocol(EntanglementProtocol, ABC):
 
         Args:
             name (str): Name of the protocol to register.
-            protocol_class (Type[BBPSSWProtocol], optional): The protocol class to register
+            protocol_class (type[BBPSSWProtocol], optional): The protocol class to register
 
         Returns:
             If used as a decorator, returns the decorator function.

--- a/sequence/resource_management/resource_manager.py
+++ b/sequence/resource_management/resource_manager.py
@@ -7,7 +7,7 @@ This module also defines the message type used by the resource manager.
 
 from __future__ import annotations
 from enum import Enum, auto
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 from collections.abc import Callable
 
 from .action_condition_set import (
@@ -317,7 +317,7 @@ class ResourceManager:
             for memory in protocol.memories:
                 self.update(protocol, memory, MemoryInfo.RAW)
 
-    def update(self, protocol: Optional[EntanglementProtocol], memory: Memory, state: str) -> None:
+    def update(self, protocol: EntanglementProtocol | None, memory: Memory, state: str) -> None:
         """Method to update state of memory after completion of entanglement management protocol.
 
         Args:

--- a/sequence/resource_management/rule_manager.py
+++ b/sequence/resource_management/rule_manager.py
@@ -4,7 +4,7 @@ This module defines the rule manager, which is used by the resource manager to i
 This is achieved through rules (also defined in this module), which if met define a set of actions to take.
 """
 from __future__ import annotations
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 from collections.abc import Callable
 from ..utils import log
 if TYPE_CHECKING:
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from .resource_manager import ResourceManager
     from ..network_management.reservation import Reservation
 
-ActionReturn = tuple["EntanglementProtocol", list[Optional[str]], list[Optional[Callable[[list["EntanglementProtocol"], dict[str, Any]], Optional["EntanglementProtocol"]]]], list[Optional[dict[str, Any]]]]
+ActionReturn = tuple["EntanglementProtocol", list[str | None], list[Callable[[list["EntanglementProtocol"], dict[str, Any]], "EntanglementProtocol" | None] | None], list[dict[str, Any] | None]]
 
 ActionFunc = Callable[[list["MemoryInfo"], dict[str, Any]], ActionReturn]
 
@@ -134,7 +134,7 @@ class Rule:
         self.condition_args: Arguments = condition_args
         self.protocols: list[EntanglementProtocol] = []
         self.rule_manager = None
-        self.reservation: Optional["Reservation"] = None
+        self.reservation: "Reservation" | None = None
 
     def __str__(self):
         action_name_list = str(self.action).split(' ')

--- a/sequence/topology/node.py
+++ b/sequence/topology/node.py
@@ -4,8 +4,10 @@ This module provides definitions for various types of quantum network nodes.
 All node types inherit from the base Node type, which inherits from Entity.
 Node types can be used to collect all the necessary hardware and software for a network usage scenario.
 """
+from __future__ import annotations
+
 from math import inf
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -197,14 +199,14 @@ class Node(Entity):
             return [comp for comp in self.components.values() if isinstance(comp, component_type)]
         return []
 
-    def get_component_by_name(self, name: str) -> Optional["Entity"]:
+    def get_component_by_name(self, name: str) -> Entity | None:
         """Method to return the component with the given name.
 
         Args:
             name (str): The name of the component to retrieve.
 
         Returns:
-            Optional[Entity]: The component with the given name, or None if not found.
+            Entity | None: The component with the given name, or None if not found.
         """
         return self.timeline.get_entity_by_name(name)
 

--- a/sequence/topology/topology.py
+++ b/sequence/topology/topology.py
@@ -6,7 +6,7 @@ Topology instances automatically perform many useful network functions.
 """
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..kernel.timeline import Timeline


### PR DESCRIPTION
Closes #287

### Changes

**CI/CD:** Removed Python 3.11 from the test matrix in `validation.yml`.

**Documentation:** Updated `requires-python` to `>=3.12` in
`pyproject.toml`, removed the 3.11 classifier, and updated the
README installation section.

**Code modernization:** Replaced deprecated `typing` imports across
10 files in compliance with PEP 585 (builtin generics) and PEP 604
(union types with `|`):
- `Optional[X]` → `X | None`
- `List` → `list`, `Dict` → `dict`, `Tuple` → `tuple`,
  `Type` → `type`

All changes are cosmetic — no logic changes, no new dependencies.