### PR TITLE
Simulation Config Schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0] - 2026-3-02
 ### Added
+- Create schema for the simulation runner using Pydantic. Include CLI and api versions
 - Add a module to convert an arbitrary graph object to sequence configurations for QuantumRouter with MIM BSM
 - Add FatTree topology and BCube topology 
 - Added the `routing` module: a new parent class `RoutingProtocol` for the subclasses `StaticRoutingProtocol` and `DistributedRoutingProtocol`. The register decorator is used to make it easy to plug in new routing protocols in the future.
@@ -20,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introducing `EARLY_EXPIRE` message type. A request has a `start_time` and `end_time`. When a request is finished before the `end_time`, then the reservation (and the associated rules) should expire early. If not, the quantum network will keep generating entanglement pairs because the rules still exist.
 
 ### Changed
+- Added all built-ins to `constants.py`
 - Using typer for CLI, creates a unified interface for topology generation. Allow for custom graph objects in CLI.
 - Moved all old topologies to NetworkX graph objects
 - Docstring, comment, logging, and various cosmetic updates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0] - 2026-3-02
 ### Added
-- Create schema for the simulation runner using Pydantic. Include CLI and api versions
+- Create schema for the simulation runner using Pydantic. Include CLI and API versions.
 - Add a module to convert an arbitrary graph object to sequence configurations for QuantumRouter with MIM BSM
 - Add FatTree topology and BCube topology 
 - Added the `routing` module: a new parent class `RoutingProtocol` for the subclasses `StaticRoutingProtocol` and `DistributedRoutingProtocol`. The register decorator is used to make it easy to plug in new routing protocols in the future.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "numpy>=2.3.5",
     "pandas>=2.3.3",
     "plotly>=6.5.0",
+    "pydantic>=2.13.4",
     "pytest>=9.0.2",
     "pyyaml>=6.0.3",
     "qutip>=5.2.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
 
 [project.scripts]
 generate-topology = "sequence.utils.config_generator_cli:app"
-validate-config = "sequence.runner.parser:app"
+check-config = "sequence.runner.parser:app"
 
 [build-system]
 requires = ["uv_build>=0.11.11,<0.12"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
 
 [project.scripts]
 generate-topology = "sequence.utils.config_generator_cli:app"
+validate-config = "sequence.runner.parser:app"
 
 [build-system]
 requires = ["uv_build>=0.11.11,<0.12"]

--- a/sequence/constants.py
+++ b/sequence/constants.py
@@ -67,6 +67,6 @@ NM_DISTRIBUTED: Final = 'distributed'
 ROUTING_STATIC: Final = 'routing_static'
 ROUTING_DISTRIBUTED: Final = 'routing_distributed'
 
-#: Build-in Applications
+#: Built-in Applications
 REQUEST_APP: Final = 'request_app'
 TELEPORT_APP: Final = 'teleport_app'

--- a/sequence/constants.py
+++ b/sequence/constants.py
@@ -53,7 +53,7 @@ FOCK_DENSITY_MATRIX_FORMALISM: Final = "fock_density"
 BELL_DIAGONAL_STATE_FORMALISM: Final = "bell_diagonal"
 
 #: Built-in Barrett-Kok generation protocol identifier.
-BARRET_KOK: Final = 'barret_kok'
+BARRETT_KOK: Final = 'barret_kok'
 #: Built-in single-heralded generation protocol identifier.
 SINGLE_HERALDED: Final = 'single_heralded'
 

--- a/sequence/constants.py
+++ b/sequence/constants.py
@@ -53,7 +53,7 @@ FOCK_DENSITY_MATRIX_FORMALISM: Final = "fock_density"
 BELL_DIAGONAL_STATE_FORMALISM: Final = "bell_diagonal"
 
 #: Built-in Barrett-Kok generation protocol identifier.
-BARRETT_KOK: Final = 'barret_kok'
+BARRETT_KOK: Final = 'barrett_kok'
 #: Built-in single-heralded generation protocol identifier.
 SINGLE_HERALDED: Final = 'single_heralded'
 

--- a/sequence/constants.py
+++ b/sequence/constants.py
@@ -56,3 +56,17 @@ BELL_DIAGONAL_STATE_FORMALISM: Final = "bell_diagonal"
 BARRET_KOK: Final = 'barret_kok'
 #: Built-in single-heralded generation protocol identifier.
 SINGLE_HERALDED: Final = 'single_heralded'
+
+#: Built-in Purification
+BBPSSW: Final = 'bbpssw'
+
+#: Built-in Network Manager
+NM_DISTRIBUTED: Final = 'distributed'
+
+#: Built-in Routing
+ROUTING_STATIC: Final = 'routing_static'
+ROUTING_DISTRIBUTED: Final = 'routing_distributed'
+
+#: Build-in Applications
+REQUEST_APP: Final = 'request_app'
+TELEPORT_APP: Final = 'teleport_app'

--- a/sequence/entanglement_management/generation/barret_kok.py
+++ b/sequence/entanglement_management/generation/barret_kok.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from ...components.bsm import SingleAtomBSM
 
 from ...resource_management.memory_manager import MemoryInfo
-from ...constants import BARRET_KOK
+from ...constants import BARRETT_KOK
 from .generation_base import EntanglementGenerationA, EntanglementGenerationB, QuantumCircuitMixin
 
 from ...kernel.event import Event
@@ -16,7 +16,7 @@ from ...kernel.process import Process
 from ...utils import log
 
 
-@EntanglementGenerationA.register(BARRET_KOK)
+@EntanglementGenerationA.register(BARRETT_KOK)
 class BarretKokA(EntanglementGenerationA, QuantumCircuitMixin):
     """Entanglement generation protocol for quantum router.
 
@@ -47,7 +47,7 @@ class BarretKokA(EntanglementGenerationA, QuantumCircuitMixin):
             raise ValueError(f"Unexpected keyword arguments: {kwargs}")
 
         super().__init__(owner, name, middle, other, memory)
-        self.protocol_type = BARRET_KOK
+        self.protocol_type = BARRETT_KOK
         self.bsm_res = [-1, -1]
         self.fidelity: float = memory.raw_fidelity
 
@@ -228,7 +228,7 @@ class BarretKokA(EntanglementGenerationA, QuantumCircuitMixin):
         self.update_resource_manager(self.memory, MemoryInfo.ENTANGLED)
 
 
-@EntanglementGenerationB.register(BARRET_KOK)
+@EntanglementGenerationB.register(BARRETT_KOK)
 class BarretKokB(EntanglementGenerationB):
     """Entanglement generation protocol for BSM node.
 
@@ -250,7 +250,7 @@ class BarretKokB(EntanglementGenerationB):
             others (list[str]): name of protocol instance on end nodes.
         """
         super().__init__(owner, name, others)
-        self.protocol_type = BARRET_KOK
+        self.protocol_type = BARRETT_KOK
 
     def bsm_update(self, bsm: "SingleAtomBSM", info: dict[str, Any]):
         assert info['info_type'] == "BSM_res"

--- a/sequence/entanglement_management/generation/generation_base.py
+++ b/sequence/entanglement_management/generation/generation_base.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 from .generation_message import EntanglementGenerationMessage, GenerationMsgType
 from ...resource_management.memory_manager import MemoryInfo
-from ...constants import BARRET_KOK
+from ...constants import BARRETT_KOK
 
 if TYPE_CHECKING:
     from ...components.memory import Memory
@@ -51,10 +51,10 @@ class EntanglementGenerationA(EntanglementProtocol, ABC):
         _qstate_key (int): The key of the quantum states associated with the memory used in the protocol.
     """
     _registry: dict[str, type['EntanglementGenerationA']] = {}
-    _global_type: str = BARRET_KOK
+    _global_type: str = BARRETT_KOK
 
     def __init__(self, owner: "Node", name: str, middle: str, other: str, memory: "Memory", **kwargs):
-        super().__init__(owner, name, BARRET_KOK)
+        super().__init__(owner, name, BARRETT_KOK)
         self.middle: str = middle
         self.remote_node_name: str = other
         self.remote_protocol_name: str = ''
@@ -112,7 +112,7 @@ class EntanglementGenerationA(EntanglementProtocol, ABC):
 
     @classmethod
     def clear_global(cls):
-        cls._global_type = BARRET_KOK
+        cls._global_type = BARRETT_KOK
 
     @classmethod
     def list_protocols(cls) -> list[str]:
@@ -187,11 +187,11 @@ class EntanglementGenerationA(EntanglementProtocol, ABC):
 
 class EntanglementGenerationB(EntanglementProtocol, ABC):
     _registry: dict[str, type['EntanglementGenerationB']] = {}
-    _global_type: str = BARRET_KOK
+    _global_type: str = BARRETT_KOK
 
     def __init__(self, owner: "BSMNode", name: str, others: list[str], **kwargs) -> None:
         super().__init__(owner, name)
-        self.protocol_type = BARRET_KOK
+        self.protocol_type = BARRETT_KOK
         assert len(others) == 2
         self.others = others
 

--- a/sequence/network_management/network_manager.py
+++ b/sequence/network_management/network_manager.py
@@ -18,7 +18,8 @@ from ..utils import log
 from .forwarding import ForwardingProtocol
 from .memory_timecard import MemoryTimeCard
 from .reservation import Reservation
-from .routing import RoutingProtocol, ROUTING_STATIC
+from .routing import RoutingProtocol
+from ..constants import ROUTING_STATIC, NM_DISTRIBUTED
 from .rsvp import RSVPMessage, RSVPMsgType, RSVPProtocol
 
 
@@ -56,7 +57,7 @@ class NetworkManager(ABC):
                                           each timecard is associated with a memory in the memory array.
     """
     _registry: dict[str, type['NetworkManager']] = {}
-    _global_type: str = 'distributed'
+    _global_type: str = NM_DISTRIBUTED
 
     def __init__(self, owner: QuantumRouter, memory_array_name: str, **kwargs):
         if kwargs:
@@ -132,7 +133,7 @@ class NetworkManager(ABC):
         self.owner.resource_manager.generate_load_rules(reservation.path, reservation, self.timecards, self.memory_array_name)
 
 
-@NetworkManager.register('distributed')
+@NetworkManager.register(NM_DISTRIBUTED)
 class DistributedNetworkManager(NetworkManager):
     """The default Network Manager implementation.
 

--- a/sequence/network_management/routing/__init__.py
+++ b/sequence/network_management/routing/__init__.py
@@ -1,4 +1,5 @@
-from .routing_base import RoutingProtocol, ROUTING_STATIC, ROUTING_DISTRIBUTED
+from .routing_base import RoutingProtocol
+from ...constants import ROUTING_STATIC, ROUTING_DISTRIBUTED
 from .routing_distributed import DistributedRoutingProtocol
 from .routing_static import StaticRoutingProtocol
 

--- a/sequence/network_management/routing/routing_base.py
+++ b/sequence/network_management/routing/routing_base.py
@@ -14,12 +14,6 @@ from ...message import Message
 from ...protocol import Protocol
 from ...utils import log
 
-
-# type labels for routing protocols:
-ROUTING_STATIC      = 'routing_static'
-ROUTING_DISTRIBUTED = 'routing_distributed'
-
-
 class RoutingProtocol(Protocol, ABC):
     """Abstract base class for routing protocols.
     """

--- a/sequence/network_management/routing/routing_distributed.py
+++ b/sequence/network_management/routing/routing_distributed.py
@@ -13,8 +13,8 @@ from typing import TYPE_CHECKING, Iterator
 if TYPE_CHECKING:
     from sequence.topology.node import QuantumRouter
 
-from .routing_base import RoutingProtocol, ROUTING_DISTRIBUTED
-from ...constants import EPSILON, SECOND
+from .routing_base import RoutingProtocol
+from ...constants import EPSILON, SECOND, ROUTING_DISTRIBUTED
 from ...kernel.event import Event
 from ...kernel.process import Process
 from ...message import Message

--- a/sequence/network_management/routing/routing_static.py
+++ b/sequence/network_management/routing/routing_static.py
@@ -10,7 +10,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from ...topology.node import QuantumRouter
 
-from .routing_base import RoutingProtocol, ROUTING_STATIC
+from .routing_base import RoutingProtocol
+from ...constants import ROUTING_STATIC
 from ...message import Message
 
 

--- a/sequence/runner/parser.py
+++ b/sequence/runner/parser.py
@@ -92,7 +92,7 @@ class Experiment(BaseModel):
     model_config = ConfigDict(extra='forbid')
     cores: PositiveInt = Field(default_factory=lambda: os.cpu_count() or 1)
     repetitions: Repetitions
-    topologies: list[str]
+    topologies: list[str] = Field(min_length=1)
     traffic_pattern: Annotated[StochasticPattern | ManualPattern, Field(discriminator="type")]
 
 class Simulation(BaseModel):
@@ -162,8 +162,8 @@ def load_config(path: str | Path) -> Simulation:
 
 
 @app.command()
-def validate(path: str):
-    """Validate a SeQUeNCe experiment config file."""
+def check(path: str):
+    """Check a SeQUeNCe experiment config file."""
     schema = load_config(path)
     typer.echo(schema.model_dump_json(indent=2))
 

--- a/sequence/runner/parser.py
+++ b/sequence/runner/parser.py
@@ -4,31 +4,35 @@ Parse and validate a simulation configuration file.
 import os
 from importlib.util import find_spec
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, Annotated
 
 import typer
 import yaml
 import json
-from pydantic import BaseModel, ConfigDict, Field, model_validator, PositiveInt, PositiveFloat
+from pydantic import BaseModel, ConfigDict, Field, model_validator, PositiveInt, PositiveFloat, NonNegativeInt
 
 from ..constants import (KET_VECTOR_FORMALISM, DENSITY_MATRIX_FORMALISM, FOCK_DENSITY_MATRIX_FORMALISM,
-                         BELL_DIAGONAL_STATE_FORMALISM, BARRET_KOK, SINGLE_HERALDED, BBPSSW, NM_DISTRIBUTED,
+                         BELL_DIAGONAL_STATE_FORMALISM, BARRETT_KOK, SINGLE_HERALDED, BBPSSW, NM_DISTRIBUTED,
                          ROUTING_STATIC, ROUTING_DISTRIBUTED, REQUEST_APP, TELEPORT_APP)
+
+BUILTIN_NAMES: set[str] = {KET_VECTOR_FORMALISM, DENSITY_MATRIX_FORMALISM, FOCK_DENSITY_MATRIX_FORMALISM,
+                         BELL_DIAGONAL_STATE_FORMALISM, BARRETT_KOK, SINGLE_HERALDED, BBPSSW, NM_DISTRIBUTED,
+                         ROUTING_STATIC, ROUTING_DISTRIBUTED, REQUEST_APP, TELEPORT_APP}
 
 app = typer.Typer()
 
 
 class Module(BaseModel):
     model_config = ConfigDict(extra='forbid')
-    name: str = Field(description="Registered module name or user-supplied import name")
-    kwargs: dict[str, Any] = Field(default_factory=dict, description="Module-specific configuration")
+    name: str = Field(description='Registered module name or user-supplied import name')
+    kwargs: dict[str, Any] = Field(default_factory=dict, description='Module-specific configuration')
 
 
 class Logging(BaseModel):
     model_config = ConfigDict(extra='forbid')
     enabled: bool
     level: Literal['INFO', 'DEBUG', 'WARNING', 'ERROR', 'CRITICAL'] = 'INFO'
-    modules: list[str] = []
+    modules: list[str] = Field(default_factory=list, description='Modules to be logged')
 
     @model_validator(mode='after')
     def check_modules_when_enabled(self):
@@ -47,13 +51,13 @@ class Configuration(BaseModel):
     application: Module
     stop_time: float = Field(gt=0)
     logging: Logging | None = Field(default=None)
-    custom_modules: list[Module] = []
+    custom_modules: list[Module] = Field(default_factory=list, description='Custom modules to be used. Must appear in imports.')
 
 
 class Repetitions(BaseModel):
     model_config = ConfigDict(extra='forbid')
     reps: PositiveInt
-    seed: Literal['random'] | list[int] = 'random'
+    seed: Literal['random'] | list[NonNegativeInt] = 'random'
 
     @model_validator(mode='after')
     def check_seed_length(self):
@@ -84,30 +88,28 @@ class ManualPattern(BaseModel):
     connections: list[tuple[str, str, PositiveFloat]] # src, dst, rate
 
 
-TrafficPattern = StochasticPattern | ManualPattern
-
-
 class Experiment(BaseModel):
     model_config = ConfigDict(extra='forbid')
     cores: PositiveInt = Field(default_factory=lambda: os.cpu_count() or 1)
     repetitions: Repetitions
     topologies: list[str]
-    traffic_pattern: TrafficPattern | None = Field(default=None, discriminator='type')
-
+    traffic_pattern: Annotated[StochasticPattern | ManualPattern, Field(discriminator="type")]
 
 class Simulation(BaseModel):
     model_config = ConfigDict(extra='forbid')
-    imports: list[str] = []
+    imports: list[str] = Field(default_factory=list)
     configuration: Configuration
     experiment: Experiment
 
     @model_validator(mode='after')
     def check_imports_exist(self):
         for name in self.imports:
-            if find_spec(name) is None:
-                raise ValueError(
-                    f"Import '{name}' is not findable on sys.path"
-                )
+            try:
+                spec = find_spec(name)
+            except (ImportError, ValueError):
+                spec = None
+            if spec is None:
+                raise ValueError(f"Import '{name}' is not findable on sys.path")
         return self
 
     @model_validator(mode='after')
@@ -117,7 +119,7 @@ class Simulation(BaseModel):
             ('formalism', self.configuration.formalism.name, {KET_VECTOR_FORMALISM, DENSITY_MATRIX_FORMALISM,
                                                               FOCK_DENSITY_MATRIX_FORMALISM,
                                                               BELL_DIAGONAL_STATE_FORMALISM}),
-            ('generation_protocol', self.configuration.generation_protocol.name, {BARRET_KOK, SINGLE_HERALDED}),
+            ('generation_protocol', self.configuration.generation_protocol.name, {BARRETT_KOK, SINGLE_HERALDED}),
             ('purification_protocol', self.configuration.purification_protocol.name, {BBPSSW}),
             ('network_manager', self.configuration.network_manager.name, {NM_DISTRIBUTED}),
             ('routing_protocol', self.configuration.routing_protocol.name, {ROUTING_STATIC, ROUTING_DISTRIBUTED}),
@@ -127,10 +129,12 @@ class Simulation(BaseModel):
         for field, name, builtins in slots:
             if name not in builtins and name not in user_imports:
                 raise ValueError(
-                    f'{field} references {name} that is not a SeQUeNCe builtin and is not in config imports')
+                    f'{field} references {name} that is not a SeQUeNCe builtin and is not in config imports.')
         for module in self.configuration.custom_modules:
+            if module.name in BUILTIN_NAMES:
+                raise ValueError(f'Custom module {module.name!r} shadows a SeQUeNCe built-in.')
             if module.name not in user_imports:
-                raise ValueError(f'Custom module entry is not in config imports: {module.name}')
+                raise ValueError(f'Custom module entry is not in config imports: {module.name}.')
         return self
 
 

--- a/sequence/runner/parser.py
+++ b/sequence/runner/parser.py
@@ -1,12 +1,18 @@
 """
 Takes a sequence .yaml file as input and validates it against the schema.
 """
+import os
+from importlib.util import find_spec
+from pathlib import Path
 from typing import Any, Literal
+
+import typer
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, model_validator
-import os
-from pathlib import Path
-import typer
+
+from ..constants import (KET_VECTOR_FORMALISM, DENSITY_MATRIX_FORMALISM, FOCK_DENSITY_MATRIX_FORMALISM,
+                         BELL_DIAGONAL_STATE_FORMALISM, BARRET_KOK, SINGLE_HERALDED, BBPSSW, NM_DISTRIBUTED,
+                         ROUTING_STATIC, ROUTING_DISTRIBUTED, REQUEST_APP, TELEPORT_APP)
 
 app = typer.Typer()
 
@@ -36,7 +42,6 @@ class Configuration(BaseModel):
     generation_protocol: Module
     purification_protocol: Module
     network_manager: Module
-    resource_manager: Module
     routing_protocol: Module
     application: Module
     stop_time: float = Field(gt=0)
@@ -90,6 +95,38 @@ class Simulation(BaseModel):
     configuration: Configuration
     experiment: Experiment
 
+    @model_validator(mode='after')
+    def check_imports_exist(self):
+        for name in self.imports:
+            if find_spec(name) is None:
+                raise ValueError(
+                    f"Import '{name}' is not findable on sys.path"
+                )
+        return self
+
+    @model_validator(mode='after')
+    def check_module_names(self):
+        user_imports = set(self.imports)
+        slots = [
+            ('formalism', self.configuration.formalism.name, {KET_VECTOR_FORMALISM, DENSITY_MATRIX_FORMALISM,
+                                                              FOCK_DENSITY_MATRIX_FORMALISM,
+                                                              BELL_DIAGONAL_STATE_FORMALISM}),
+            ('generation_protocol', self.configuration.generation_protocol.name, {BARRET_KOK, SINGLE_HERALDED}),
+            ('purification_protocol', self.configuration.purification_protocol.name, {BBPSSW}),
+            ('network_manager', self.configuration.network_manager.name, {NM_DISTRIBUTED}),
+            ('routing_protocol', self.configuration.routing_protocol.name, {ROUTING_STATIC, ROUTING_DISTRIBUTED}),
+            ('application', self.configuration.application.name, {REQUEST_APP, TELEPORT_APP}),
+        ]
+
+        for field, name, builtins in slots:
+            if name not in builtins and name not in user_imports:
+                raise ValueError(
+                    f'{field} references {name} that is not a SeQUeNCe builtin and is not in config imports')
+        for module in self.configuration.custom_modules:
+            if module.name not in user_imports:
+                raise ValueError(f'Custom module entry is not in config imports: {module.name}')
+        return self
+
 
 def load_config(path: str | Path) -> Simulation:
     with open(path, 'r') as f:
@@ -99,10 +136,11 @@ def load_config(path: str | Path) -> Simulation:
 
     return Simulation(**raw)
 
+
 @app.command()
 def validate(path: str):
     schema = load_config(path)
-    typer.echo(schema)
+    typer.echo(schema.model_dump_json(indent=2))
 
 
 if __name__ == '__main__':

--- a/sequence/runner/parser.py
+++ b/sequence/runner/parser.py
@@ -20,8 +20,8 @@ app = typer.Typer()
 
 class Module(BaseModel):
     model_config = ConfigDict(extra='forbid')
-    name: str
-    kwargs: dict[str, Any] = {}
+    name: str = Field(description="Registered module name or user-supplied import name")
+    kwargs: dict[str, Any] = Field(default_factory=dict, description="Module-specific configuration")
 
 
 class Logging(BaseModel):
@@ -130,6 +130,14 @@ class Simulation(BaseModel):
 
 
 def load_config(path: str | Path) -> Simulation:
+    """
+    Takes the config file (.yml, .yaml, .json) as input and returns a validated Simulation() object.
+    Args:
+        path: str or pathlib.Path object of the configuration file.
+
+    Returns: Validated Simulation object
+
+    """
     path = Path(path)
     suffix = path.suffix.lower()
     loaders = {'.yml': yaml.safe_load, '.yaml': yaml.safe_load, '.json': json.load}
@@ -146,6 +154,7 @@ def load_config(path: str | Path) -> Simulation:
 
 @app.command()
 def validate(path: str):
+    """Validate a SeQUeNCe experiment config file."""
     schema = load_config(path)
     typer.echo(schema.model_dump_json(indent=2))
 

--- a/sequence/runner/parser.py
+++ b/sequence/runner/parser.py
@@ -9,7 +9,7 @@ from typing import Any, Literal
 import typer
 import yaml
 import json
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator, PositiveInt, PositiveFloat
 
 from ..constants import (KET_VECTOR_FORMALISM, DENSITY_MATRIX_FORMALISM, FOCK_DENSITY_MATRIX_FORMALISM,
                          BELL_DIAGONAL_STATE_FORMALISM, BARRET_KOK, SINGLE_HERALDED, BBPSSW, NM_DISTRIBUTED,
@@ -52,7 +52,7 @@ class Configuration(BaseModel):
 
 class Repetitions(BaseModel):
     model_config = ConfigDict(extra='forbid')
-    reps: int
+    reps: PositiveInt
     seed: Literal['random'] | list[int] = 'random'
 
     @model_validator(mode='after')
@@ -65,18 +65,23 @@ class Repetitions(BaseModel):
 class StochasticPattern(BaseModel):
     model_config = ConfigDict(extra='forbid')
     type: Literal['stochastic']
-    maximum_duration: int
-    pairs: int
+    maximum_duration: PositiveInt
+    pairs: PositiveInt
     distribution: Literal['poisson', 'bernoulli']
-    rate: float
+    rate: PositiveFloat # Poisson rate (lambda), Bernoulli prob (p)
 
+    @model_validator(mode='after')
+    def check_rate(self):
+        if self.distribution == 'bernoulli' and self.rate > 1:
+            raise ValueError('Bernoulli rate must be in (0,1]')
+        return self
 
 class ManualPattern(BaseModel):
     model_config = ConfigDict(extra='forbid')
     type: Literal['manual']
-    maximum_duration: int
-    pairs: int
-    connections: list[tuple[str, str, float]]
+    maximum_duration: PositiveInt
+    pairs: PositiveInt
+    connections: list[tuple[str, str, PositiveFloat]] # src, dst, rate
 
 
 TrafficPattern = StochasticPattern | ManualPattern
@@ -84,7 +89,7 @@ TrafficPattern = StochasticPattern | ManualPattern
 
 class Experiment(BaseModel):
     model_config = ConfigDict(extra='forbid')
-    cores: int = Field(default_factory=lambda: os.cpu_count() or 1)
+    cores: PositiveInt = Field(default_factory=lambda: os.cpu_count() or 1)
     repetitions: Repetitions
     topologies: list[str]
     traffic_pattern: TrafficPattern | None = Field(default=None, discriminator='type')
@@ -142,7 +147,7 @@ def load_config(path: str | Path) -> Simulation:
     suffix = path.suffix.lower()
     loaders = {'.yml': yaml.safe_load, '.yaml': yaml.safe_load, '.json': json.load}
     loader = loaders.get(suffix)
-    if loaders is None:
+    if loader is None:
         raise ValueError(f'Unsupported config extension: {suffix}')
     with open(path, 'r') as f:
         raw = loader(f)

--- a/sequence/runner/parser.py
+++ b/sequence/runner/parser.py
@@ -7,7 +7,7 @@ from collections import Counter
 from importlib.util import find_spec
 from pathlib import Path
 from typing import Annotated, Any, Literal
-
+from ..utils.graphs import TOPOLOGY_BUILDERS
 import typer
 import yaml
 from pydantic import (
@@ -152,7 +152,7 @@ class Simulation(BaseModel):
             except (ImportError, ValueError):
                 spec = None
             if spec is None:
-                raise ValueError(f"Import '{name}' is not findable on sys.path")
+                raise ValueError(f'Import '{name}' is not findable on sys.path')
         return self
 
     @model_validator(mode='after')
@@ -169,15 +169,22 @@ class Simulation(BaseModel):
             ('application', self.configuration.application.name, {REQUEST_APP, TELEPORT_APP}),
         ]
 
+        all_builtins: set[str] = BUILTIN_NAMES | TOPOLOGY_BUILDERS.keys()
+        shadowed: set[str] = user_imports & all_builtins
+        if shadowed:
+            raise ValueError(f'Imports shadow built-in modules: {sorted(shadowed)}')
+        
         for field, name, builtins in slots:
             if name not in builtins and name not in user_imports:
                 raise ValueError(
                     f'{field} references {name} that is not a SeQUeNCe builtin and is not in config imports.')
         for module in self.configuration.custom_modules:
-            if module.name in BUILTIN_NAMES:
-                raise ValueError(f'Custom module {module.name!r} shadows a SeQUeNCe built-in.')
             if module.name not in user_imports:
-                raise ValueError(f'Custom module entry is not in config imports: {module.name}.')
+                raise ValueError(f'Custom module entry is not in config imports: {module.name!r}.')
+        for topology in self.experiment.topologies:
+            if topology not in user_imports and topology not in TOPOLOGY_BUILDERS:
+                raise ValueError(f'Custom topology entry not in config imports and is not a SeQUeNCe built-in: {topology!r}')
+
         return self
 
 
@@ -209,7 +216,6 @@ def check(path: str):
     """Check a SeQUeNCe experiment config file."""
     schema = load_config(path)
     typer.echo(schema.model_dump_json(indent=2))
-
 
 if __name__ == '__main__':
     app()

--- a/sequence/runner/parser.py
+++ b/sequence/runner/parser.py
@@ -1,0 +1,87 @@
+"""
+Takes a sequence yaml file as input and validates it against the schema
+"""
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+import os
+
+
+class Module(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    name: str
+    kwargs: dict[str, Any] = {}
+
+
+class Logging(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    enabled: bool
+    level: Literal['INFO', 'DEBUG', 'WARNING', 'ERROR', 'CRITICAL'] = 'INFO'
+    modules: list[str] = []
+
+    @model_validator(mode='after')
+    def check_modules_when_enabled(self):
+        if self.enabled and not self.modules:
+            raise ValueError('Modules must be specified when logging is enabled')
+        return self
+
+
+class Configuration(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    formalism: Module
+    generation_protocol: Module
+    purification_protocol: Module
+    network_manager: Module
+    resource_manager: Module
+    routing_protocol: Module
+    application: Module
+    stop_time: float = Field(gt=0)
+    logging: Logging | None = Field(default=None)
+    custom_modules: list[Module] = []
+
+
+class Repetitions(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    reps: int
+    seed: Literal['random'] | list[int] = 'random'
+
+    @model_validator(mode='after')
+    def check_seed_length(self):
+        if isinstance(self.seed, list) and len(self.seed) != self.reps:
+            raise ValueError(f'Seed list length ({len(self.seed)}) must match the number of repetitions {self.reps}')
+        return self
+
+
+class StochasticPattern(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    type: Literal['stochastic']
+    maximum_duration: int
+    pairs: int
+    distribution: Literal['poisson', 'bernoulli']
+    rate: float
+
+
+class ManualPattern(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    type: Literal['manual']
+    maximum_duration: int
+    pairs: int
+    connections: list[tuple[str, str, float]]
+
+
+TrafficPattern = StochasticPattern | ManualPattern
+
+
+class Experiment(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    cores: int = Field(default_factory=lambda: os.cpu_count() or 1)
+    repetitions: Repetitions
+    topologies: list[str]
+    traffic_pattern: TrafficPattern | None = Field(default=None, discriminator='type')
+
+
+class Simulation(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    imports: list[str] = []
+    configuration: Configuration
+    experiment: Experiment

--- a/sequence/runner/parser.py
+++ b/sequence/runner/parser.py
@@ -1,5 +1,5 @@
 """
-Takes a sequence .yaml file as input and validates it against the schema.
+Parse and validate a simulation configuration file.
 """
 import os
 from importlib.util import find_spec
@@ -8,6 +8,7 @@ from typing import Any, Literal
 
 import typer
 import yaml
+import json
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from ..constants import (KET_VECTOR_FORMALISM, DENSITY_MATRIX_FORMALISM, FOCK_DENSITY_MATRIX_FORMALISM,
@@ -129,8 +130,14 @@ class Simulation(BaseModel):
 
 
 def load_config(path: str | Path) -> Simulation:
+    path = Path(path)
+    suffix = path.suffix.lower()
+    loaders = {'.yml': yaml.safe_load, '.yaml': yaml.safe_load, '.json': json.load}
+    loader = loaders.get(suffix)
+    if loaders is None:
+        raise ValueError(f'Unsupported config extension: {suffix}')
     with open(path, 'r') as f:
-        raw = yaml.safe_load(f)
+        raw = loader(f)
     if raw is None:
         raise ValueError(f'Config file is empty: {path}')
 

--- a/sequence/runner/parser.py
+++ b/sequence/runner/parser.py
@@ -1,7 +1,6 @@
 """
 Parse and validate a simulation configuration file.
 """
-from jedi.inference.base_value import Value
 import os
 from importlib.util import find_spec
 from pathlib import Path

--- a/sequence/runner/parser.py
+++ b/sequence/runner/parser.py
@@ -7,7 +7,7 @@ from collections import Counter
 from importlib.util import find_spec
 from pathlib import Path
 from typing import Annotated, Any, Literal
-from ..utils.graphs import TOPOLOGY_BUILDERS
+
 import typer
 import yaml
 from pydantic import (
@@ -35,6 +35,7 @@ from ..constants import (
     SINGLE_HERALDED,
     TELEPORT_APP,
 )
+from ..utils.graphs import TOPOLOGY_BUILDERS
 
 BUILTIN_NAMES: set[str] = {KET_VECTOR_FORMALISM, DENSITY_MATRIX_FORMALISM, FOCK_DENSITY_MATRIX_FORMALISM,
                          BELL_DIAGONAL_STATE_FORMALISM, BARRETT_KOK, SINGLE_HERALDED, BBPSSW, NM_DISTRIBUTED,

--- a/sequence/runner/parser.py
+++ b/sequence/runner/parser.py
@@ -152,7 +152,7 @@ class Simulation(BaseModel):
             except (ImportError, ValueError):
                 spec = None
             if spec is None:
-                raise ValueError(f'Import '{name}' is not findable on sys.path')
+                raise ValueError(f'Import {name!r} is not findable on sys.path')
         return self
 
     @model_validator(mode='after')

--- a/sequence/runner/parser.py
+++ b/sequence/runner/parser.py
@@ -1,6 +1,7 @@
 """
 Parse and validate a simulation configuration file.
 """
+from jedi.inference.base_value import Value
 import os
 from importlib.util import find_spec
 from pathlib import Path
@@ -9,7 +10,7 @@ from typing import Any, Literal
 import typer
 import yaml
 import json
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator, PositiveInt, PositiveFloat
 
 from ..constants import (KET_VECTOR_FORMALISM, DENSITY_MATRIX_FORMALISM, FOCK_DENSITY_MATRIX_FORMALISM,
                          BELL_DIAGONAL_STATE_FORMALISM, BARRET_KOK, SINGLE_HERALDED, BBPSSW, NM_DISTRIBUTED,
@@ -52,7 +53,7 @@ class Configuration(BaseModel):
 
 class Repetitions(BaseModel):
     model_config = ConfigDict(extra='forbid')
-    reps: int
+    reps: PositiveInt
     seed: Literal['random'] | list[int] = 'random'
 
     @model_validator(mode='after')
@@ -65,18 +66,23 @@ class Repetitions(BaseModel):
 class StochasticPattern(BaseModel):
     model_config = ConfigDict(extra='forbid')
     type: Literal['stochastic']
-    maximum_duration: int
-    pairs: int
+    maximum_duration: PositiveInt
+    pairs: PositiveInt
     distribution: Literal['poisson', 'bernoulli']
-    rate: float
+    rate: PositiveFloat # Poisson rate (lambda), Bernoulli prob (p)
 
+    @model_validator(mode='after')
+    def check_rate(self):
+        if self.distribution == 'bernoulli' and self.rate > 1:
+            raise ValueError('Bernoulli rate must be in (0,1]')
+        return self
 
 class ManualPattern(BaseModel):
     model_config = ConfigDict(extra='forbid')
     type: Literal['manual']
-    maximum_duration: int
-    pairs: int
-    connections: list[tuple[str, str, float]]
+    maximum_duration: PositiveInt
+    pairs: PositiveInt
+    connections: list[tuple[str, str, PositiveFloat]] # src, dst, rate
 
 
 TrafficPattern = StochasticPattern | ManualPattern
@@ -84,7 +90,7 @@ TrafficPattern = StochasticPattern | ManualPattern
 
 class Experiment(BaseModel):
     model_config = ConfigDict(extra='forbid')
-    cores: int = Field(default_factory=lambda: os.cpu_count() or 1)
+    cores: PositiveInt = Field(default_factory=lambda: os.cpu_count() or 1)
     repetitions: Repetitions
     topologies: list[str]
     traffic_pattern: TrafficPattern | None = Field(default=None, discriminator='type')
@@ -142,7 +148,7 @@ def load_config(path: str | Path) -> Simulation:
     suffix = path.suffix.lower()
     loaders = {'.yml': yaml.safe_load, '.yaml': yaml.safe_load, '.json': json.load}
     loader = loaders.get(suffix)
-    if loaders is None:
+    if loader is None:
         raise ValueError(f'Unsupported config extension: {suffix}')
     with open(path, 'r') as f:
         raw = loader(f)

--- a/sequence/runner/parser.py
+++ b/sequence/runner/parser.py
@@ -1,19 +1,40 @@
 """
 Parse and validate a simulation configuration file.
 """
+import json
 import os
+from collections import Counter
 from importlib.util import find_spec
 from pathlib import Path
-from typing import Any, Literal, Annotated
+from typing import Annotated, Any, Literal
 
 import typer
 import yaml
-import json
-from pydantic import BaseModel, ConfigDict, Field, model_validator, PositiveInt, PositiveFloat, NonNegativeInt
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    NonNegativeInt,
+    PositiveFloat,
+    PositiveInt,
+    field_validator,
+    model_validator,
+)
 
-from ..constants import (KET_VECTOR_FORMALISM, DENSITY_MATRIX_FORMALISM, FOCK_DENSITY_MATRIX_FORMALISM,
-                         BELL_DIAGONAL_STATE_FORMALISM, BARRETT_KOK, SINGLE_HERALDED, BBPSSW, NM_DISTRIBUTED,
-                         ROUTING_STATIC, ROUTING_DISTRIBUTED, REQUEST_APP, TELEPORT_APP)
+from ..constants import (
+    BARRETT_KOK,
+    BBPSSW,
+    BELL_DIAGONAL_STATE_FORMALISM,
+    DENSITY_MATRIX_FORMALISM,
+    FOCK_DENSITY_MATRIX_FORMALISM,
+    KET_VECTOR_FORMALISM,
+    NM_DISTRIBUTED,
+    REQUEST_APP,
+    ROUTING_DISTRIBUTED,
+    ROUTING_STATIC,
+    SINGLE_HERALDED,
+    TELEPORT_APP,
+)
 
 BUILTIN_NAMES: set[str] = {KET_VECTOR_FORMALISM, DENSITY_MATRIX_FORMALISM, FOCK_DENSITY_MATRIX_FORMALISM,
                          BELL_DIAGONAL_STATE_FORMALISM, BARRETT_KOK, SINGLE_HERALDED, BBPSSW, NM_DISTRIBUTED,
@@ -21,6 +42,10 @@ BUILTIN_NAMES: set[str] = {KET_VECTOR_FORMALISM, DENSITY_MATRIX_FORMALISM, FOCK_
 
 app = typer.Typer()
 
+def check_unique(items: list, label: str) -> None:
+    duplicates = [item for item, count in Counter(items).items() if count > 1]
+    if duplicates:
+        raise ValueError(f'Found duplicate {label}: {duplicates}')
 
 class Module(BaseModel):
     model_config = ConfigDict(extra='forbid')
@@ -52,6 +77,12 @@ class Configuration(BaseModel):
     stop_time: float = Field(gt=0)
     logging: Logging | None = Field(default=None)
     custom_modules: list[Module] = Field(default_factory=list, description='Custom modules to be used. Must appear in imports.')
+
+    @field_validator('custom_modules', mode='after')
+    @classmethod
+    def is_custom_modules_unique(cls, v: list[Module]) -> list[Module]:
+        check_unique([m.name for m in v], 'custom_modules names')
+        return v
 
 
 class Repetitions(BaseModel):
@@ -95,11 +126,23 @@ class Experiment(BaseModel):
     topologies: list[str] = Field(min_length=1)
     traffic_pattern: Annotated[StochasticPattern | ManualPattern, Field(discriminator="type")]
 
+    @field_validator('topologies', mode='after')
+    @classmethod
+    def is_topologies_unique(cls, v: list[str]) -> list[str]:
+        check_unique(v, 'topologies')
+        return v
+
 class Simulation(BaseModel):
     model_config = ConfigDict(extra='forbid')
     imports: list[str] = Field(default_factory=list)
     configuration: Configuration
     experiment: Experiment
+
+    @field_validator('imports', mode='after')
+    @classmethod
+    def is_imports_unique(cls, v: list[str]) -> list[str]:
+        check_unique(v, 'imports')
+        return v
 
     @model_validator(mode='after')
     def check_imports_exist(self):
@@ -153,7 +196,7 @@ def load_config(path: str | Path) -> Simulation:
     loader = loaders.get(suffix)
     if loader is None:
         raise ValueError(f'Unsupported config extension: {suffix}')
-    with open(path, 'r') as f:
+    with open(path, 'r', encoding='utf-8') as f:
         raw = loader(f)
     if raw is None:
         raise ValueError(f'Config file is empty: {path}')

--- a/sequence/runner/parser.py
+++ b/sequence/runner/parser.py
@@ -1,10 +1,14 @@
 """
-Takes a sequence yaml file as input and validates it against the schema
+Takes a sequence .yaml file as input and validates it against the schema.
 """
 from typing import Any, Literal
-
+import yaml
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 import os
+from pathlib import Path
+import typer
+
+app = typer.Typer()
 
 
 class Module(BaseModel):
@@ -85,3 +89,21 @@ class Simulation(BaseModel):
     imports: list[str] = []
     configuration: Configuration
     experiment: Experiment
+
+
+def load_config(path: str | Path) -> Simulation:
+    with open(path, 'r') as f:
+        raw = yaml.safe_load(f)
+    if raw is None:
+        raise ValueError(f'Config file is empty: {path}')
+
+    return Simulation(**raw)
+
+@app.command()
+def validate(path: str):
+    schema = load_config(path)
+    typer.echo(schema)
+
+
+if __name__ == '__main__':
+    app()

--- a/sequence/utils/graphs.py
+++ b/sequence/utils/graphs.py
@@ -7,6 +7,7 @@ entanglement distribution. Switch nodes are assumed to never be end points.
 from itertools import product
 from math import dist
 import networkx as nx
+from collections.abc import Callable
 
 def build_caveman(cliques: int, size: int, length: float=10.0, attenuation: float=0.0002) -> nx.Graph:
     """
@@ -254,3 +255,15 @@ def build_k_n(k: int, n: int, length: float=10.0, attenuation: float=0.0002) -> 
     assert G.number_of_edges() == n * k**n
 
     return G
+
+TOPOLOGY_BUILDERS: dict[str, Callable[..., nx.Graph]] = {'caveman': build_caveman, 'grid': build_grid,
+                                                         'star': build_star, 'linear': build_linear, 'mesh': build_mesh,
+                                                         'ring': build_ring, 'waxman': build_waxman, 'tree': build_tree,
+                                                         'auto_system': build_autonomous_system, 'bcube': build_bcube,
+                                                         'kn_tree': build_k_n}
+
+
+def register_topology(name: str, builder: Callable[..., nx.Graph]) -> None:
+    if name in TOPOLOGY_BUILDERS:
+        raise ValueError(f'Topology {name!r} is already registered')
+    TOPOLOGY_BUILDERS[name] = builder

--- a/tests/entanglement_management/test_generation.py
+++ b/tests/entanglement_management/test_generation.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from sequence.constants import BARRET_KOK
+from sequence.constants import BARRETT_KOK
 from sequence.components.bsm import *
 from sequence.components.memory import MemoryArray
 from sequence.components.optical_channel import *
@@ -46,7 +46,7 @@ class FakeBSMNode(Node):
 
 
 def test_generation_message():
-    msg = EntanglementGenerationMessage(GenerationMsgType.NEGOTIATE, "alice", protocol_type=BARRET_KOK, qc_delay=1)
+    msg = EntanglementGenerationMessage(GenerationMsgType.NEGOTIATE, "alice", protocol_type=BARRETT_KOK, qc_delay=1)
 
     assert msg.receiver == "alice"
     assert msg.msg_type == GenerationMsgType.NEGOTIATE
@@ -67,7 +67,7 @@ def test_generation_receive_message():
     eg.qc_delay = 1
 
     # negotiate message
-    msg = EntanglementGenerationMessage(GenerationMsgType.NEGOTIATE_ACK, "EG", protocol_type=BARRET_KOK, emit_time=0)
+    msg = EntanglementGenerationMessage(GenerationMsgType.NEGOTIATE_ACK, "EG", protocol_type=BARRETT_KOK, emit_time=0)
     eg.received_message("e2", msg)
     assert eg.expected_time == 1
     assert len(tl.events.data) == 2  # two excites, flip state, end time

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1825,6 +1834,96 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2336,6 +2435,7 @@ dependencies = [
     { name = "numpy" },
     { name = "pandas" },
     { name = "plotly" },
+    { name = "pydantic" },
     { name = "pytest" },
     { name = "pyyaml" },
     { name = "qutip" },
@@ -2372,6 +2472,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.3.5" },
     { name = "pandas", specifier = ">=2.3.3" },
     { name = "plotly", specifier = ">=6.5.0" },
+    { name = "pydantic", specifier = ">=2.13.4" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "qutip", specifier = ">=5.2.2" },
@@ -2562,6 +2663,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the codebase, primarily focused on centralizing protocol and application constants, updating imports to use the new constants, and adding a new configuration parser and validator for the simulation YAML files. The most important changes are summarized below.

### Configuration Validation and Parsing

* Added a new `parser.py` module that uses Pydantic to define and validate the structure of simulation YAML configuration files, ensuring correctness and providing helpful error messages. This module includes detailed models for modules, logging, configuration, experiments, and traffic patterns, and a CLI command for validating configuration files.

### Centralization of Constants

* Moved protocol and application string constants (such as `ROUTING_STATIC`, `ROUTING_DISTRIBUTED`, `NM_DISTRIBUTED`, etc.) into `sequence/constants.py` for centralized management and easier reference throughout the codebase.

### Refactoring Imports to Use Centralized Constants

* Updated all relevant imports in network management and routing modules to use the centralized constants from `sequence/constants.py` instead of defining them locally, improving maintainability and reducing duplication. [[1]](diffhunk://#diff-bc71d2e640d508a0471a1eb66f3944b280c03e1b33c4c916c7b7c432724da894L21-R22) [[2]](diffhunk://#diff-12cbe112b21eda74f1ae0e2344d89f2f94bf6bfa59138a5f2ed98f5ee6f97537L1-R2) [[3]](diffhunk://#diff-71c3c59018b920c7cc83a7bde97b409435347d7918a1b092ea458cec674dacd1L16-R17) [[4]](diffhunk://#diff-2b521b53cacf2b76e0b9cd3413fef7f54c15d50be9752f3ddfe3a1258ce5c229L13-R14) [[5]](diffhunk://#diff-777d01994bcab26c6c86b39f28862523765378161caaf200b2692d204d18cfb3L17-L22)

### Dependency Update

* Added `pydantic` to the `pyproject.toml` dependencies to support the new configuration validation functionality.

### Minor Refactorings

* Updated the registration and default values for network manager types to use the new constants, ensuring consistency across the codebase. [[1]](diffhunk://#diff-bc71d2e640d508a0471a1eb66f3944b280c03e1b33c4c916c7b7c432724da894L59-R60) [[2]](diffhunk://#diff-bc71d2e640d508a0471a1eb66f3944b280c03e1b33c4c916c7b7c432724da894L135-R136)