### PR TITLE
Bring swapping_success_prob and swapping_degradation Back for Entanglement Swapping Parameterization

### DIFF
--- a/sequence/network_management/rsvp.py
+++ b/sequence/network_management/rsvp.py
@@ -222,18 +222,11 @@ class RSVPProtocol(StackProtocol):
 
         raise Exception(f"RSVP protocol {self.name} received a message (disallowed)")
 
-    # def set_swapping_success_rate(self, prob: float) -> None:
-    #     assert 0 <= prob <= 1
-    #     self.es_succ_prob = prob
-
-    # def set_swapping_degradation(self, degradation: float) -> None:
-    #     assert 0 <= degradation <= 1
-    #     self.es_degradation = degradation
-
     def set_purification_mode(self, mode: str) -> None:
         assert mode in ['once', 'until_target'], \
             f'Purification mode {mode} not supported, should be either "once" or "until_target"'
         self.purification_mode = mode
+
 
 class QCap:
     """Quantum Capacity. Class to collect local information for the reservation protocol

--- a/sequence/resource_management/action_condition_set.py
+++ b/sequence/resource_management/action_condition_set.py
@@ -323,7 +323,7 @@ def ep_match_func(protocols: list[EntanglementProtocol], args: Arguments) -> BBP
 
 
 # Entanglement Swapping Action-Condition-Match
-def es_rule_action_A(memories_info: list[MemoryInfo], _args: Arguments) -> ActionReturn:
+def es_rule_action_A(memories_info: list[MemoryInfo], args: Arguments) -> ActionReturn:
     """Action function used to create an EntanglementSwappingA protocol instance on all interior nodes.
        
     Interior nodes of a path are the nodes that are neither the initiator nor the responder.
@@ -334,17 +334,21 @@ def es_rule_action_A(memories_info: list[MemoryInfo], _args: Arguments) -> Actio
     
     Args:
         memories_info: a list of memory info
-        _args: the arguments defined in the rule (not used in this action function)
+        args: the arguments defined in the rule
     
     Returns:
         ActionReturn: the protocol to be executed, the destination of the request, the request function,
             and the arguments for request function
     """
-    # TODO: add es_succ_prob and es_degradation into arguments
-    # es_succ_prob = args["es_succ_prob"]
-    # es_degradation = args["es_degradation"]
+    success_prob = args.get("swapping_success_prob", 1)
+    degradation = args.get("swapping_degradation", None)
+    kwargs = {}
+    if degradation is not None:
+        kwargs["degradation"] = degradation
+
     memories = [info.memory for info in memories_info]
-    protocol = EntanglementSwappingA.create(TempNode, f"ESA.{memories[0].name}.{memories[1].name}", memories[0], memories[1])
+    protocol = EntanglementSwappingA.create(TempNode, f"ESA.{memories[0].name}.{memories[1].name}",
+                                            memories[0], memories[1], success_prob, **kwargs)
     dsts = [info.remote_node for info in memories_info]
     req_funcs: list[RequestFunction | None] = [es_match_func, es_match_func]
     req_args = [{"target_memo": memories_info[0].remote_memo}, {"target_memo": memories_info[1].remote_memo}]

--- a/sequence/resource_management/resource_manager.py
+++ b/sequence/resource_management/resource_manager.py
@@ -239,7 +239,8 @@ class ResourceManager:
 
             condition_args = {"memory_indices": memory_indices, "left": left, "right": right,
                               "fidelity": reservation.fidelity}
-            action_args = {}
+            action_args = {"swapping_success_prob": self.owner.swapping_success_prob, 
+                           "swapping_degradation": self.owner.swapping_degradation}
             rule = Rule(10, es_rule_action_A, es_rule_condition_A, action_args, condition_args)
             rules.append(rule)
 

--- a/sequence/topology/node.py
+++ b/sequence/topology/node.py
@@ -308,6 +308,8 @@ class QuantumRouter(Node):
         map_to_middle_node (dict[str, str]): mapping of router names to intermediate bsm node names.
         app (any): application in use on node.
         down (bool): whether the node is down (not operational).
+        swapping_success_prob (float): the success probability of entanglement swapping performed by this node (Default 1).
+        swapping_degradation (float | None): the degradation of entanglement swapping performed by this node (Default None).
     """
 
     def __init__(self, name: str, tl: "Timeline", memo_size: int = 50, seed: int | None = None, component_templates: dict = {}, gate_fid: float = 1, meas_fid: float = 1):
@@ -320,9 +322,9 @@ class QuantumRouter(Node):
             seed (int): the random seed for the random number generator
             component_templates (dict): parameters for the quantum router
             gate_fid (float): fidelity of multi-qubit gates (usually CNOT) that can be performed on the node;
-                Default value is 1, meaning ideal gate.
+                              Default value is 1, meaning ideal gate.
             meas_fid (float): fidelity of single-qubit measurements (usually Z measurement) that can be performed on the node;
-                Default value is 1, meaning ideal measurement.
+                              Default value is 1, meaning ideal measurement.
         """
 
         super().__init__(name, tl, seed, gate_fid, meas_fid)
@@ -340,7 +342,7 @@ class QuantumRouter(Node):
         self.app = None
         self.down = False
         swapping_args = component_templates.get("EntanglementSwapping", {})
-        self.swapping_success_prob = swapping_args.get("swapping_success_prob", None)
+        self.swapping_success_prob = swapping_args.get("swapping_success_prob", 1)
         self.swapping_degradation = swapping_args.get("swapping_degradation", None)
 
 

--- a/sequence/topology/node.py
+++ b/sequence/topology/node.py
@@ -210,7 +210,7 @@ class Node(Entity):
         Returns:
             Entity | None: The component with the given name, or None if not found.
         """
-        return self.timeline.get_entity_by_name(name)
+        return self.components.get(name, None)
 
     def change_timeline(self, timeline: "Timeline"):
         self.timeline = timeline
@@ -339,6 +339,10 @@ class QuantumRouter(Node):
         self.map_to_middle_node = {}
         self.app = None
         self.down = False
+        swapping_args = component_templates.get("EntanglementSwapping", {})
+        self.swapping_success_prob = swapping_args.get("swapping_success_prob", None)
+        self.swapping_degradation = swapping_args.get("swapping_degradation", None)
+
 
     def receive_message(self, src: str, msg: "Message") -> None:
         """Determine what to do when a message is received, based on the msg.receiver.

--- a/sequence/topology/router_net_topo.py
+++ b/sequence/topology/router_net_topo.py
@@ -33,11 +33,23 @@ class RouterNetTopo(Topo):
     CONTROLLER = "Controller"
 
     def __init__(self, config_source: str | dict):
+        """
+        Constructor for RouterNetTopo class.
+
+        Args:
+            config_source (str | dict): the name of configuration file or the config dictionary
+        """
         self.bsm_to_router_map = {}
         self.encoding_type = None
         super().__init__(config_source)
 
     def _load(self, config_source: str | dict):
+        """
+        Method for parsing configuration file and generate network
+
+        Args:
+            config_source (str | dict): the name of configuration file or the config dictionary
+        """
         config = super()._load(config_source)
         self._get_templates(config)
         # quantum connections are only supported by sequential simulation so far
@@ -58,7 +70,7 @@ class RouterNetTopo(Topo):
         QuantumManager.set_global_manager_formalism(formalism)
         self.tl = Timeline(stop_time=stop_time, truncation=truncation)
 
-    def _map_bsm_routers(self, config):
+    def _map_bsm_routers(self, config: dict):
         for qc in config[Topo.ALL_Q_CHANNEL]:
             src, dst = qc[Topo.SRC], qc[Topo.DST]
             if dst in self.bsm_to_router_map:

--- a/sequence/topology/topology.py
+++ b/sequence/topology/topology.py
@@ -59,7 +59,7 @@ class Topology(ABC):
         """Constructor for topology class.
 
         Args:
-            config_source (str): the name of configuration file
+            config_source (str | dict): the name of configuration file or the config dictionary
         """
         self.nodes: dict[str, list[Node]] = defaultdict(list)
         self.qchannels: list[QuantumChannel] = []
@@ -73,7 +73,7 @@ class Topology(ABC):
         """Method for parsing configuration file and generate network
 
         Args:
-            config (str|dict): Config object
+            config_source (str | dict): Config object
         """
         if isinstance(config_source, str):
             with open(config_source) as f:

--- a/tests/topology/router_net_topo_sample_config.json
+++ b/tests/topology/router_net_topo_sample_config.json
@@ -1,100 +1,183 @@
 {
-    "stop_time": 100,
-    "templates": {
-        "perfect_memo": {
-            "MemoryArray": {
-                "fidelity": 1.0
-            }
-        }
+  "templates": {
+    "router_template": {
+      "routing": "routing_distributed",
+      "MemoryArray": {
+        "fidelity": 0.95,
+        "efficiency": 0.6,
+        "coherence_time": 2,
+        "decoherence_errors": [
+          0.3333333333333333,
+          0.3333333333333333,
+          0.3333333333333333
+        ]
+      },
+      "EntanglementSwapping": {
+        "swapping_success_prob": 0.99,
+        "swapping_degradation": 0.99
+      }
     },
-    "nodes": [
-        {
-            "name": "e1",
-            "type": "QuantumRouter",
-            "seed": 0,
-            "group": 0,
-            "memo_size": 20,
-            "template": "perfect_memo"
-        },
-        {
-            "name": "e2",
-            "type": "QuantumRouter",
-            "seed": 1,
-            "group": 0,
-            "memo_size": 20
-        },
-        {
-            "name": "e3",
-            "type": "QuantumRouter",
-            "seed": 2,
-            "group": 0,
-            "memo_size": 20
-        },
-        {
-            "name": "e4",
-            "type": "QuantumRouter",
-            "seed": 3,
-            "group": 0,
-            "memo_size": 20
-        },
-        {
-            "name": "bsm0",
-            "type": "BSMNode",
-            "seed": 4,
-            "group": 0
-        }
-    ],
-    "qchannels": [
-        {
-            "source": "e1",
-            "destination": "bsm0",
-            "attenuation": 0.0002,
-            "distance": 1000
-        },
-        {
-            "source": "e2",
-            "destination": "bsm0",
-            "attenuation": 0.0002,
-            "distance": 1000
-        }
-    ],
-    "qconnections": [
-        {
-            "node1": "e3",
-            "node2": "e4",
-            "attenuation": 0.0002,
-            "distance": 2000,
-            "type": "meet_in_the_middle"
-        }
-    ],
-    "cchannels": [
-        {
-            "source": "e1",
-            "destination": "bsm0",
-            "delay": 1000000000
-        },
-        {
-            "source": "e2",
-            "destination": "bsm0",
-            "delay": 1000000000
-        },
-        {
-            "source": "e1",
-            "destination": "e2",
-            "delay": 1000000000
-        },
-        {
-            "source": "e2",
-            "destination": "e1",
-            "delay": 1000000000
-        }
-    ],
-    "cconnections": [
-        {
-            "node1": "e3",
-            "node2": "e4",
-            "distance": 5e3,
-            "delay": 1000000000
-        }
-    ]
+    "bsm_template": {
+      "encoding_type": "single_heralded",
+      "SingleHeraldedBSM": {
+        "detectors": [
+          {
+            "efficiency": 0.95
+          },
+          {
+            "efficiency": 0.95
+          }
+        ]
+      }
+    }
+  },
+  "nodes": [
+    {
+      "name": "router_0",
+      "type": "QuantumRouter",
+      "seed": 0,
+      "memo_size": 5,
+      "template": "router_template",
+      "gate_fidelity": 0.99,
+      "measurement_fidelity": 0.99
+    },
+    {
+      "name": "router_1",
+      "type": "QuantumRouter",
+      "seed": 1,
+      "memo_size": 5,
+      "template": "router_template",
+      "gate_fidelity": 0.99,
+      "measurement_fidelity": 0.99
+    },
+    {
+      "name": "router_2",
+      "type": "QuantumRouter",
+      "seed": 2,
+      "memo_size": 5,
+      "template": "router_template",
+      "gate_fidelity": 0.99,
+      "measurement_fidelity": 0.99
+    },
+    {
+      "name": "BSM_router_0_router_1",
+      "type": "BSMNode",
+      "seed": 0,
+      "template": "bsm_template"
+    },
+    {
+      "name": "BSM_router_1_router_2",
+      "type": "BSMNode",
+      "seed": 1,
+      "template": "bsm_template"
+    }
+  ],
+  "qchannels": [
+    {
+      "source": "router_0",
+      "destination": "BSM_router_0_router_1",
+      "distance": 2500.0,
+      "attenuation": 0.0002
+    },
+    {
+      "source": "router_1",
+      "destination": "BSM_router_0_router_1",
+      "distance": 2500.0,
+      "attenuation": 0.0002
+    },
+    {
+      "source": "router_1",
+      "destination": "BSM_router_1_router_2",
+      "distance": 2500.0,
+      "attenuation": 0.0002
+    },
+    {
+      "source": "router_2",
+      "destination": "BSM_router_1_router_2",
+      "distance": 2500.0,
+      "attenuation": 0.0002
+    }
+  ],
+  "cchannels": [
+    {
+      "source": "router_0",
+      "destination": "BSM_router_0_router_1",
+      "distance": 2500.0,
+      "delay": 0
+    },
+    {
+      "source": "BSM_router_0_router_1",
+      "destination": "router_0",
+      "distance": 2500.0,
+      "delay": 0
+    },
+    {
+      "source": "router_1",
+      "destination": "BSM_router_0_router_1",
+      "distance": 2500.0,
+      "delay": 0
+    },
+    {
+      "source": "BSM_router_0_router_1",
+      "destination": "router_1",
+      "distance": 2500.0,
+      "delay": 0
+    },
+    {
+      "source": "router_1",
+      "destination": "BSM_router_1_router_2",
+      "distance": 2500.0,
+      "delay": 0
+    },
+    {
+      "source": "BSM_router_1_router_2",
+      "destination": "router_1",
+      "distance": 2500.0,
+      "delay": 0
+    },
+    {
+      "source": "router_2",
+      "destination": "BSM_router_1_router_2",
+      "distance": 2500.0,
+      "delay": 0
+    },
+    {
+      "source": "BSM_router_1_router_2",
+      "destination": "router_2",
+      "distance": 2500.0,
+      "delay": 0
+    },
+    {
+      "source": "router_0",
+      "destination": "router_1",
+      "delay": 0
+    },
+    {
+      "source": "router_0",
+      "destination": "router_2",
+      "delay": 0
+    },
+    {
+      "source": "router_1",
+      "destination": "router_0",
+      "delay": 0
+    },
+    {
+      "source": "router_1",
+      "destination": "router_2",
+      "delay": 0
+    },
+    {
+      "source": "router_2",
+      "destination": "router_0",
+      "delay": 0
+    },
+    {
+      "source": "router_2",
+      "destination": "router_1",
+      "delay": 0
+    }
+  ],
+  "stop_time": 1000000000000,
+  "formalism": "bell_diagonal"
 }

--- a/tests/topology/router_net_topo_sample_config.json
+++ b/tests/topology/router_net_topo_sample_config.json
@@ -13,8 +13,7 @@
         ]
       },
       "EntanglementSwapping": {
-        "swapping_success_prob": 0.99,
-        "swapping_degradation": 0.99
+        "swapping_success_prob": 0.99
       }
     },
     "bsm_template": {

--- a/tests/topology/test_router_net_topo.py
+++ b/tests/topology/test_router_net_topo.py
@@ -94,6 +94,3 @@ def test_router_net_topo_config():
             assert memory.efficiency == 0.6
             assert memory.coherence_time == 2
             assert memory.decoherence_errors == pytest.approx([1/3, 1/3, 1/3], abs=EPSILON)
-
-
-test_router_net_topo_config()

--- a/tests/topology/test_router_net_topo.py
+++ b/tests/topology/test_router_net_topo.py
@@ -1,6 +1,7 @@
-from sequence.constants import SECOND
+from sequence.constants import SECOND, EPSILON
 from sequence.topology.router_net_topo import RouterNetTopo
 from sequence.utils import nx_converter, graphs
+from sequence.network_management.routing.routing_distributed import DistributedRoutingProtocol
 import pytest
 
 GRAPHS = {
@@ -76,3 +77,23 @@ class TestRouterNetTopo:
         nodes = topo.get_nodes()
         assert len(nodes[RouterNetTopo.QUANTUM_ROUTER]) == graph.number_of_nodes()
         assert len(nodes[RouterNetTopo.BSM_NODE]) == graph.number_of_edges()
+
+
+def test_router_net_topo_config():
+    config_file = 'tests/topology/router_net_topo_sample_config.json'
+    topo = RouterNetTopo(config_file)
+    for node in topo.get_nodes_by_type(RouterNetTopo.QUANTUM_ROUTER):
+        routing_protocol = node.network_manager.get_routing_protocol()
+        assert isinstance(routing_protocol, DistributedRoutingProtocol)
+        assert node.swapping_success_prob == 0.99
+        assert node.swapping_degradation == 0.99
+        memory_array = node.get_component_by_name(node.memo_arr_name)
+        assert len(memory_array) == 5
+        for memory in memory_array.memories:
+            assert memory.raw_fidelity == 0.95
+            assert memory.efficiency == 0.6
+            assert memory.coherence_time == 2
+            assert memory.decoherence_errors == pytest.approx([1/3, 1/3, 1/3], abs=EPSILON)
+
+
+test_router_net_topo_config()

--- a/tests/topology/test_router_net_topo.py
+++ b/tests/topology/test_router_net_topo.py
@@ -86,7 +86,7 @@ def test_router_net_topo_config():
         routing_protocol = node.network_manager.get_routing_protocol()
         assert isinstance(routing_protocol, DistributedRoutingProtocol)
         assert node.swapping_success_prob == 0.99
-        assert node.swapping_degradation == 0.99
+        assert node.swapping_degradation is None
         memory_array = node.get_component_by_name(node.memo_arr_name)
         assert len(memory_array) == 5
         for memory in memory_array.memories:


### PR DESCRIPTION
This pull request brings back the `swapping_success_prob` and the `swapping_degradation`.
1.  Add two new attributes `swapping_success_prob` and `swapping_degradation` to the `QuantumRouter` (this is the best place to put it, and I don't see a better place for now).  Not so long ago, those two attributes were part of the `RSVPProtocol` and latter removed. See https://github.com/sequence-toolbox/SeQUeNCe/blob/d135e9f8fd4b21bb76bcf3933966e6b984d818c3/sequence/network_management/rsvp.py#L227 https://github.com/sequence-toolbox/SeQUeNCe/blob/d135e9f8fd4b21bb76bcf3933966e6b984d818c3/sequence/network_management/rsvp.py#L231
2. `swapping_success_prob` and `swapping_degradation` are readable from the config file
3. `ResourceManager` and `action_condition_set` are modified to adjust to the above changes for entanglement swapping parameterization
4. A new `tests/topology/router_net_topo_sample_config.json` built from the new config generator. A new unit test is built on top of it. See `tests/topology/test_router_net_topo.py`
5. Various cosmetic updates