### PR TITLE
MVP implementation of centralized metrics tracking system

### DIFF
--- a/example/eg_experiment/README.md
+++ b/example/eg_experiment/README.md
@@ -1,0 +1,39 @@
+# Entanglement Generation Metrics Experiment
+
+This quick experiment demonstrates the built-in `metrics` module by running 
+a SingleHeralded entanglement generation experiment on a two-node linear 
+topology and plotting:
+
+- **Success rate vs initial fidelity** (`success_rate_vs_fidelity.png`)
+- **Running success rate vs simulation time** (`success_rate_vs_time.png`)
+
+## Generate Topology
+
+Generate the network config:
+
+A `two_node.json` configuration is already provided in the directory, but
+this command is what is used to generate it.
+
+```bash
+generate-topology linear 2 \
+  --memory-size 64 \
+  --formalism bell_diagonal \
+  --output two_node.json \
+  --directory example/eg_experiment
+```
+
+## Run Experiment
+
+```bash
+uv run python example/eg_experiment/eg_experiment.py
+```
+
+Results are written to this directory:
+
+- `output_eg_exp.csv` — aggregated trial metrics per initial fidelity
+- `success_rate_vs_fidelity.png`
+- `success_rate_vs_time.png`
+
+The experiment structure follows
+[eg_symmetric_experiment.py](https://github.com/sequence-toolbox/entanglement_purification_experiment/blob/6c49f649bdacfeebefcd85c91e9902151d775368/eg_symmetric_experiment.py),
+but uses `sequence.utils.metrics` instead of monkey-patching `QuantumRouter`.

--- a/example/eg_experiment/eg_experiment.py
+++ b/example/eg_experiment/eg_experiment.py
@@ -40,32 +40,6 @@ def modify_config(config_file: Path, fidelity: float) -> None:
         json.dump(config, file, indent=2)
 
 
-def collect_trial_metrics(app_start: RequestApp) -> dict:
-    """Collect per-trial metrics from the metrics module for the app node."""
-    node = app_start.node.name
-    return {
-        "eg_failures": metrics.get_failures(node),
-        "eg_success": metrics.get_successes(node),
-        "eg_success_rate": metrics.get_success_rate(node),
-        "app_throughput": app_start.get_throughput(),
-        "event_records": metrics.storage.get_by_owner(node),
-    }
-
-
-def aggregate_trial_metrics(trial_metrics: list[dict]) -> dict:
-    """Aggregate scalar metrics across trials (mirrors eg_symmetric_experiment.py)."""
-    scalar_metrics = [key for key in trial_metrics[0] if key != "event_records"]
-
-    aggregated = {}
-    for metric in scalar_metrics:
-        values = [trial[metric] for trial in trial_metrics]
-        aggregated[f"avg_{metric}"] = np.mean(values)
-        if len(values) > 0:
-            aggregated[f"std_{metric}"] = np.std(values)
-
-    return aggregated
-
-
 def run_trial(
     config_file: Path,
     prep_time: int,
@@ -82,7 +56,7 @@ def run_trial(
     EntanglementGenerationB.set_global_type(SINGLE_HERALDED)
 
     metrics.configure(storage_type="in_memory")
-    metrics.enable([metrics.EG_FAILURE, metrics.EG_SUCCESS])
+    metrics.enable([metrics.EG_FAILURE, metrics.EG_SUCCESS, metrics.THROUGHPUT])
 
     net_topo = RouterNetTopo(str(config_file))
     qm.set_global_manager_formalism(BELL_DIAGONAL_STATE_FORMALISM)
@@ -123,7 +97,7 @@ def run_trial(
     )
     tl.run()
 
-    return collect_trial_metrics(app_start)
+    return metrics.collect_trial_metrics(app_start.node.name)
 
 
 def plot_success_rate_vs_fidelity(results: list[dict], output_path: Path) -> None:
@@ -196,7 +170,7 @@ def main() -> None:
             for trial in range(num_trials)
         ]
 
-        aggregated_metrics = aggregate_trial_metrics(trial_metrics)
+        aggregated_metrics = metrics.aggregate_trial_metrics(trial_metrics)
 
         if fidelity == time_series_fidelity:
             time_series_records = trial_metrics[0]["event_records"]

--- a/example/eg_experiment/eg_experiment.py
+++ b/example/eg_experiment/eg_experiment.py
@@ -62,7 +62,7 @@ def run_trial(
     qm.set_global_manager_formalism(BELL_DIAGONAL_STATE_FORMALISM)
 
     tl = net_topo.get_timeline()
-    tl.stop_time = prep_time + collect_time
+    tl.stop_time = prep_time + collect_time + 1
 
     routers = net_topo.get_nodes_by_type(RouterNetTopo.QUANTUM_ROUTER)
     bsm_nodes = net_topo.get_nodes_by_type(RouterNetTopo.BSM_NODE)

--- a/example/eg_experiment/eg_experiment.py
+++ b/example/eg_experiment/eg_experiment.py
@@ -1,0 +1,229 @@
+"""Entanglement generation experiment using the built-in metrics module.
+
+Runs SingleHeralded entanglement generation on a two-node linear topology and
+produces plots of success rate versus initial fidelity and success rate over time.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from sequence.app.request_app import RequestApp
+from sequence.constants import BELL_DIAGONAL_STATE_FORMALISM, SINGLE_HERALDED
+from sequence.entanglement_management.generation import (
+    EntanglementGenerationA,
+    EntanglementGenerationB,
+)
+from sequence.kernel.quantum_manager import QuantumManager as qm
+from sequence.topology.router_net_topo import RouterNetTopo
+from sequence.utils import metrics
+
+EXPERIMENT_DIR = Path(__file__).resolve().parent
+CONFIG_FILE = EXPERIMENT_DIR / "two_node.json"
+
+
+def modify_config(config_file: Path, fidelity: float) -> None:
+    """Set initial memory fidelity in the topology template."""
+    with config_file.open("r", encoding="utf-8") as file:
+        config = json.load(file)
+
+    config["templates"]["perfect_router"]["MemoryArray"]["fidelity"] = fidelity
+
+    with config_file.open("w", encoding="utf-8") as file:
+        json.dump(config, file, indent=2)
+
+
+def collect_trial_metrics(app_start: RequestApp) -> dict:
+    """Collect per-trial metrics from the metrics module for the app node."""
+    node = app_start.node.name
+    return {
+        "eg_failures": metrics.get_failures(node),
+        "eg_success": metrics.get_successes(node),
+        "eg_success_rate": metrics.get_success_rate(node),
+        "app_throughput": app_start.get_throughput(),
+        "event_records": metrics.storage.get_by_owner(node),
+    }
+
+
+def aggregate_trial_metrics(trial_metrics: list[dict]) -> dict:
+    """Aggregate scalar metrics across trials (mirrors eg_symmetric_experiment.py)."""
+    scalar_metrics = [key for key in trial_metrics[0] if key != "event_records"]
+
+    aggregated = {}
+    for metric in scalar_metrics:
+        values = [trial[metric] for trial in trial_metrics]
+        aggregated[f"avg_{metric}"] = np.mean(values)
+        if len(values) > 0:
+            aggregated[f"std_{metric}"] = np.std(values)
+
+    return aggregated
+
+
+def run_trial(
+    config_file: Path,
+    prep_time: int,
+    collect_time: int,
+    qc_freq: float,
+    app_node_name: str,
+    other_node_name: str,
+    num_memories: int,
+    fidelity: float,
+    trial: int,
+) -> dict:
+    """Run a single trial and return metrics collected from the metrics module."""
+    EntanglementGenerationA.set_global_type(SINGLE_HERALDED)
+    EntanglementGenerationB.set_global_type(SINGLE_HERALDED)
+
+    metrics.configure(storage_type="in_memory")
+    metrics.enable([metrics.EG_FAILURE, metrics.EG_SUCCESS])
+
+    net_topo = RouterNetTopo(str(config_file))
+    qm.set_global_manager_formalism(BELL_DIAGONAL_STATE_FORMALISM)
+
+    tl = net_topo.get_timeline()
+    tl.stop_time = prep_time + collect_time
+
+    routers = net_topo.get_nodes_by_type(RouterNetTopo.QUANTUM_ROUTER)
+    bsm_nodes = net_topo.get_nodes_by_type(RouterNetTopo.BSM_NODE)
+
+    base_seed = int(time.time_ns()) % (2**20) + os.getpid()
+    for j, node in enumerate(routers + bsm_nodes):
+        node.set_seed(base_seed + trial * 1000 + j)
+
+    for qc in net_topo.get_qchannels():
+        qc.frequency = qc_freq
+
+    start_node = None
+    end_node = None
+    for node in routers:
+        if node.name == app_node_name:
+            start_node = node
+        elif node.name == other_node_name:
+            end_node = node
+    if not start_node or not end_node:
+        raise ValueError("Could not find required nodes")
+
+    app_start = RequestApp(start_node)
+    RequestApp(end_node)
+
+    tl.init()
+    app_start.start(
+        other_node_name,
+        prep_time,
+        prep_time + collect_time,
+        num_memories,
+        float(fidelity),
+    )
+    tl.run()
+
+    return collect_trial_metrics(app_start)
+
+
+def plot_success_rate_vs_fidelity(results: list[dict], output_path: Path) -> None:
+    fidelities = [result["initial_fidelity"] for result in results]
+    success_rates = [result["avg_eg_success_rate"] for result in results]
+    errors = [result["std_eg_success_rate"] for result in results]
+
+    plt.figure(figsize=(8, 6))
+    plt.errorbar(fidelities, success_rates, yerr=errors, marker="o", capsize=3)
+    plt.xlabel("Initial fidelity")
+    plt.ylabel("Entanglement generation success rate")
+    plt.title("EG success rate vs initial memory fidelity")
+    plt.grid(True, alpha=0.3)
+    plt.tight_layout()
+    plt.savefig(output_path)
+    plt.close()
+
+
+def plot_success_rate_vs_time(event_records: list[dict], output_path: Path) -> None:
+    completion_events = [
+        record
+        for record in event_records
+        if record["event_type"] in (metrics.EG_FAILURE, metrics.EG_SUCCESS)
+    ]
+    completion_events.sort(key=lambda record: record["sim_time"])
+    times = [record["sim_time"] * 1e-12 for record in completion_events]
+    rates = [record["success_rate"] for record in completion_events]
+
+    plt.figure(figsize=(8, 6))
+    plt.plot(times, rates, marker=".", linestyle="-", markersize=4)
+    plt.xlabel("Simulation time (s)")
+    plt.ylabel("Running EG success rate")
+    plt.title("EG success rate vs simulation time")
+    plt.grid(True, alpha=0.3)
+    plt.tight_layout()
+    plt.savefig(output_path)
+    plt.close()
+
+
+def main() -> None:
+    num_trials = 3
+    prep_time = int(1e12)
+    collect_time = int(50e12)
+    qc_freq = 1e11
+    app_node_name = "left"
+    other_node_name = "right"
+    num_memories = 2
+    initial_fidelities = np.round(np.arange(0.6, 1.0, 0.05), 3)
+    time_series_fidelity = 0.9
+
+    results = []
+    time_series_records: list[dict] = []
+
+    for fidelity in initial_fidelities:
+        print(f"Running {num_trials} trial(s) for initial fidelity={fidelity}")
+        modify_config(CONFIG_FILE, float(fidelity))
+
+        trial_metrics = [
+            run_trial(
+                CONFIG_FILE,
+                prep_time,
+                collect_time,
+                qc_freq,
+                app_node_name,
+                other_node_name,
+                num_memories,
+                float(fidelity),
+                trial,
+            )
+            for trial in range(num_trials)
+        ]
+
+        aggregated_metrics = aggregate_trial_metrics(trial_metrics)
+
+        if fidelity == time_series_fidelity:
+            time_series_records = trial_metrics[0]["event_records"]
+
+        result = {
+            "initial_fidelity": float(fidelity),
+            "num_trials": num_trials,
+            **aggregated_metrics,
+        }
+        results.append(result)
+
+        print(
+            f"  avg success rate: {result['avg_eg_success_rate']:.3f} "
+            f"(std: {result['std_eg_success_rate']:.3f})"
+        )
+
+    df = pd.DataFrame(results)
+    df.to_csv(EXPERIMENT_DIR / "output_eg_exp.csv", index=False)
+
+    plot_success_rate_vs_fidelity(
+        results, EXPERIMENT_DIR / "success_rate_vs_fidelity.png"
+    )
+    plot_success_rate_vs_time(
+        time_series_records, EXPERIMENT_DIR / "success_rate_vs_time.png"
+    )
+    print(f"Wrote results to {EXPERIMENT_DIR}")
+
+
+if __name__ == "__main__":
+    main()

--- a/example/eg_experiment/eg_experiment.py
+++ b/example/eg_experiment/eg_experiment.py
@@ -7,6 +7,7 @@ produces plots of success rate versus initial fidelity and success rate over tim
 from __future__ import annotations
 
 import json
+import multiprocessing as mp
 import os
 import time
 from pathlib import Path
@@ -155,20 +156,37 @@ def main() -> None:
         print(f"Running {num_trials} trial(s) for initial fidelity={fidelity}")
         modify_config(CONFIG_FILE, float(fidelity))
 
-        trial_metrics = [
-            run_trial(
-                CONFIG_FILE,
-                prep_time,
-                collect_time,
-                qc_freq,
-                app_node_name,
-                other_node_name,
-                num_memories,
-                float(fidelity),
-                trial,
-            )
-            for trial in range(num_trials)
-        ]
+        if num_trials == 1:
+            trial_metrics = [
+                run_trial(
+                    CONFIG_FILE,
+                    prep_time,
+                    collect_time,
+                    qc_freq,
+                    app_node_name,
+                    other_node_name,
+                    num_memories,
+                    float(fidelity),
+                    0,
+                )
+            ]
+        else:
+            params = [
+                (
+                    CONFIG_FILE,
+                    prep_time,
+                    collect_time,
+                    qc_freq,
+                    app_node_name,
+                    other_node_name,
+                    num_memories,
+                    float(fidelity),
+                    trial,
+                )
+                for trial in range(num_trials)
+            ]
+            with mp.Pool(processes=mp.cpu_count()) as pool:
+                trial_metrics = pool.starmap(run_trial, params)
 
         aggregated_metrics = metrics.aggregate_trial_metrics(trial_metrics)
 

--- a/example/eg_experiment/eg_experiment.py
+++ b/example/eg_experiment/eg_experiment.py
@@ -97,7 +97,7 @@ def run_trial(
     )
     tl.run()
 
-    return metrics.collect_trial_metrics(app_start.node.name)
+    return metrics.collect_trial_metrics(other_node_name)
 
 
 def plot_success_rate_vs_fidelity(results: list[dict], output_path: Path) -> None:

--- a/example/eg_experiment/two_node.json
+++ b/example/eg_experiment/two_node.json
@@ -1,0 +1,67 @@
+{
+  "nodes": [
+    {
+      "name": "left",
+      "type": "QuantumRouter",
+      "seed": 0,
+      "memo_size": 2,
+      "template": "perfect_router"
+    },
+    {
+      "name": "right",
+      "type": "QuantumRouter",
+      "seed": 1,
+      "memo_size": 2,
+      "template": "perfect_router"
+    }
+  ],
+  "qconnections": [
+    {
+      "node1": "left",
+      "node2": "right",
+      "attenuation": 0.0002,
+      "distance": 40000,
+      "type": "meet_in_the_middle",
+      "template": "perfect_bsm"
+    }
+  ],
+  "cconnections": [
+    {
+      "node1": "left",
+      "node2": "right",
+      "delay": 200000000.0
+    }
+  ],
+  "templates": {
+    "perfect_router": {
+      "MemoryArray": {
+        "frequency": 200000000.0,
+        "coherence_time": -1,
+        "efficiency": 1,
+        "fidelity": 0.95,
+        "cutoff_flag": false
+      }
+    },
+    "perfect_bsm": {
+      "encoding_type": "single_heralded",
+      "SingleHeraldedBSM": {
+        "detectors": [
+          {
+            "efficiency": 1,
+            "dark_count": 0,
+            "time_resolution": 6,
+            "count_rate": 100000000000.0
+          },
+          {
+            "efficiency": 1,
+            "dark_count": 0,
+            "time_resolution": 6,
+            "count_rate": 100000000000.0
+          }
+        ]
+      }
+    }
+  },
+  "is_parallel": false,
+  "formalism": "bell_diagonal"
+}

--- a/sequence/app/request_app.py
+++ b/sequence/app/request_app.py
@@ -167,6 +167,19 @@ class RequestApp:
                 event = Event(reservation.end_time, process)
                 self.node.timeline.schedule(event)
 
+        process = Process(self, "record_throughput_metric", [])
+        event = Event(reservation.end_time, process)
+        self.node.timeline.schedule(event)
+
+    def record_throughput_metric(self) -> None:
+        from ..utils import metrics
+
+        metrics.record(
+            metrics.THROUGHPUT,
+            self.node.name,
+            throughput=self.get_throughput(),
+        )
+
     def set_name(self, name: str):
         self.name = name
 

--- a/sequence/app/request_app.py
+++ b/sequence/app/request_app.py
@@ -143,7 +143,10 @@ class RequestApp:
                 self.node.resource_manager.update(None, info.memory, "RAW")
 
     def get_throughput(self) -> float:
-        return self.memory_counter / (self.end_t - self.start_t) * 1e12
+        duration = self.end_t - self.start_t
+        if duration <= 0:
+            return float("nan")
+        return self.memory_counter / duration * 1e12
 
 
     def schedule_reservation(self, reservation: Reservation) -> None:

--- a/sequence/app/request_app.py
+++ b/sequence/app/request_app.py
@@ -167,9 +167,12 @@ class RequestApp:
                 event = Event(reservation.end_time, process)
                 self.node.timeline.schedule(event)
 
-        process = Process(self, "record_throughput_metric", [])
-        event = Event(reservation.end_time, process)
-        self.node.timeline.schedule(event)
+        if self.node.name == reservation.responder:
+            self.start_t = reservation.start_time
+            self.end_t = reservation.end_time
+            process = Process(self, "record_throughput_metric", [])
+            event = Event(reservation.end_time, process)
+            self.node.timeline.schedule(event)
 
     def record_throughput_metric(self) -> None:
         from ..utils import metrics

--- a/sequence/entanglement_management/generation/single_heralded.py
+++ b/sequence/entanglement_management/generation/single_heralded.py
@@ -11,7 +11,7 @@ from ...kernel.event import Event
 from ...kernel.process import Process
 from ...kernel.quantum_manager import QuantumManager
 from ...resource_management.memory_manager import MemoryInfo
-from ...utils import log
+from ...utils import log, metrics
 
 if TYPE_CHECKING:
     from ...components.memory import Memory
@@ -119,6 +119,8 @@ class SingleHeraldedA(EntanglementGenerationA, QuantumCircuitMixin):
         if not self.is_ready():
             log.logger.info(f'{self} is not valid, emit_event() failed.')
             return
+
+        metrics.record(metrics.EG_ATTEMPT, self.owner.name, round=self.ent_round)
 
         if self.ent_round == 1:
             self.memory.update_state(QuantumCircuitMixin._plus_state)
@@ -228,6 +230,7 @@ class SingleHeraldedA(EntanglementGenerationA, QuantumCircuitMixin):
 
     def _entanglement_succeed(self):
         log.logger.info(f'{self.owner.name} successful entanglement of memory {self.memory}')
+        metrics.record(metrics.EG_SUCCESS, self.owner.name, fidelity=self.raw_fidelity)
         self.memory.entangled_memory['node_id'] = self.remote_node_name
         self.memory.entangled_memory['memo_id'] = self.remote_memo_id
         self.memory.fidelity = self.raw_fidelity

--- a/sequence/entanglement_management/generation/single_heralded.py
+++ b/sequence/entanglement_management/generation/single_heralded.py
@@ -120,8 +120,6 @@ class SingleHeraldedA(EntanglementGenerationA, QuantumCircuitMixin):
             log.logger.info(f'{self} is not valid, emit_event() failed.')
             return
 
-        metrics.record(metrics.EG_ATTEMPT, self.owner.name, round=self.ent_round)
-
         if self.ent_round == 1:
             self.memory.update_state(QuantumCircuitMixin._plus_state)
         self.memory.excite(self.middle, protocol='sh')
@@ -227,6 +225,10 @@ class SingleHeraldedA(EntanglementGenerationA, QuantumCircuitMixin):
 
         else:
             raise Exception(f"Invalid message {msg_type} received by EG on node {self.owner.name}")
+
+    def _entanglement_fail(self):
+        metrics.record(metrics.EG_FAILURE, self.owner.name, initial_fidelity=self.raw_fidelity)
+        super()._entanglement_fail()
 
     def _entanglement_succeed(self):
         log.logger.info(f'{self.owner.name} successful entanglement of memory {self.memory}')

--- a/sequence/entanglement_management/purification/bbpssw_bds.py
+++ b/sequence/entanglement_management/purification/bbpssw_bds.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from ...topology.node import Node
 
 from ...constants import BELL_DIAGONAL_STATE_FORMALISM
-from ...utils import log
+from ...utils import log, metrics
 from .bbpssw_protocol import BBPSSWProtocol, BBPSSWMessage, BBPSSWMsgType
 
 @BBPSSWProtocol.register(BELL_DIAGONAL_STATE_FORMALISM)
@@ -137,9 +137,15 @@ class BBPSSW_BDS(BBPSSWProtocol):
                 remote_kept_memory.bds_decohere()
                 self.kept_memo.bds_decohere()
                 self.kept_memo.fidelity = self.kept_memo.get_bds_fidelity()
+                metrics.record(
+                    metrics.EP_SUCCESS,
+                    self.owner.name,
+                    fidelity=self.kept_memo.fidelity,
+                )
                 self.update_resource_manager(self.kept_memo, state="PURIFIED")
             else:
                 log.logger.info(f'Purification failed because measure results: {self.meas_res}, {msg.meas_res}')
+                metrics.record(metrics.EP_FAILURE, self.owner.name)
                 self.update_resource_manager(self.kept_memo, state="RAW")
 
         else:

--- a/sequence/kernel/timeline.py
+++ b/sequence/kernel/timeline.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 from .eventlist import EventList
 from .quantum_manager import QuantumManager
-from ..utils import log
+from ..utils import log, metrics
 
 # for timeline formatting
 NANOSECONDS_PER_MILLISECOND = 10**6
@@ -76,6 +76,7 @@ class Timeline:
         if manager_kwargs is None:
             manager_kwargs = {}
         self.quantum_manager: QuantumManager = QuantumManager.create(**manager_kwargs)
+        metrics.register_time_provider(self)
 
     def now(self) -> int:
         """Returns current simulation time."""

--- a/sequence/utils/__init__.py
+++ b/sequence/utils/__init__.py
@@ -1,3 +1,3 @@
-__all__ = ['encoding', 'log', 'config_generator_cli', 'graphs', 'nx_converter']
+__all__ = ['encoding', 'log', 'config_generator_cli', 'graphs', 'nx_converter', 'metrics']
 def __dir__():
     return sorted(__all__)

--- a/sequence/utils/metrics.py
+++ b/sequence/utils/metrics.py
@@ -19,11 +19,15 @@ class EventType(Enum):
     EG_FAILURE = auto()
     EG_SUCCESS = auto()
     THROUGHPUT = auto()
+    EP_FAILURE = auto()
+    EP_SUCCESS = auto()
 
 
 EG_FAILURE = EventType.EG_FAILURE
 EG_SUCCESS = EventType.EG_SUCCESS
 THROUGHPUT = EventType.THROUGHPUT
+EP_FAILURE = EventType.EP_FAILURE
+EP_SUCCESS = EventType.EP_SUCCESS
 
 
 class TimeProvider(Protocol):
@@ -71,6 +75,11 @@ storage = InMemoryStorage()
 _system_time_provider = SystemTimeProvider()
 time_provider: TimeProvider = _system_time_provider
 
+_eg_failures: dict[str, int] = {}
+_eg_successes: dict[str, int] = {}
+_ep_failures: dict[str, int] = {}
+_ep_successes: dict[str, int] = {}
+
 
 def register_time_provider(provider: TimeProvider) -> None:
     """Register the active time source for recorded events."""
@@ -78,31 +87,42 @@ def register_time_provider(provider: TimeProvider) -> None:
     time_provider = provider
 
 
-# TODO: Hopefully the counters and the 4 functions associated with them
-# can be generalized for purification and swapping as well
-
-# Counter dicts that contain the failure and success counters for each node
-_failures: dict[str, int] = {}
-_successes: dict[str, int] = {}
-
-
 def reset_counters() -> None:
     """Reset per-node attempt and success counters."""
-    _failures.clear()
-    _successes.clear()
+    _eg_failures.clear()
+    _eg_successes.clear()
+    _ep_failures.clear()
+    _ep_successes.clear()
 
 
-def get_failures(owner_name: str) -> int:
-    return _failures.get(owner_name, 0)
+def get_eg_failures(owner_name: str) -> int:
+    return _eg_failures.get(owner_name, 0)
 
 
-def get_successes(owner_name: str) -> int:
-    return _successes.get(owner_name, 0)
+def get_eg_successes(owner_name: str) -> int:
+    return _eg_successes.get(owner_name, 0)
 
 
-def get_success_rate(owner_name: str) -> float:
-    failures = get_failures(owner_name)
-    successes = get_successes(owner_name)
+def get_eg_success_rate(owner_name: str) -> float:
+    failures = get_eg_failures(owner_name)
+    successes = get_eg_successes(owner_name)
+    attempts = failures + successes
+    if attempts == 0:
+        return 0.0
+    return successes / attempts
+
+
+def get_ep_failures(owner_name: str) -> int:
+    return _ep_failures.get(owner_name, 0)
+
+
+def get_ep_successes(owner_name: str) -> int:
+    return _ep_successes.get(owner_name, 0)
+
+
+def get_ep_success_rate(owner_name: str) -> float:
+    failures = get_ep_failures(owner_name)
+    successes = get_ep_successes(owner_name)
     attempts = failures + successes
     if attempts == 0:
         return 0.0
@@ -136,22 +156,28 @@ def record(event_type: EventType, owner_name: str, **kwargs: Any) -> None:
 
     Will increment counter if counter is available for metric.
     Metrics with counters:
-        - EG_SUCCESS
-        - EG_FAILURE
+        - EG_SUCCESS, EG_FAILURE
+        - EP_SUCCESS, EP_FAILURE
 
     Will automatically record success rate for:
-        - EG_SUCCESS
-        - EG_FAILURE
+        - EG_SUCCESS, EG_FAILURE (as ``success_rate``)
+        - EP_SUCCESS, EP_FAILURE (as ``ep_success_rate``)
     """
     if not _enabled or event_type not in _enabled_events:
         return
 
     if event_type is EG_FAILURE:
-        _failures[owner_name] = _failures.get(owner_name, 0) + 1
-        kwargs["success_rate"] = get_success_rate(owner_name)
+        _eg_failures[owner_name] = _eg_failures.get(owner_name, 0) + 1
+        kwargs["success_rate"] = get_eg_success_rate(owner_name)
     elif event_type is EG_SUCCESS:
-        _successes[owner_name] = _successes.get(owner_name, 0) + 1
-        kwargs["success_rate"] = get_success_rate(owner_name)
+        _eg_successes[owner_name] = _eg_successes.get(owner_name, 0) + 1
+        kwargs["success_rate"] = get_eg_success_rate(owner_name)
+    elif event_type is EP_FAILURE:
+        _ep_failures[owner_name] = _ep_failures.get(owner_name, 0) + 1
+        kwargs["ep_success_rate"] = get_ep_success_rate(owner_name)
+    elif event_type is EP_SUCCESS:
+        _ep_successes[owner_name] = _ep_successes.get(owner_name, 0) + 1
+        kwargs["ep_success_rate"] = get_ep_success_rate(owner_name)
 
     storage.append(
         {
@@ -178,9 +204,12 @@ def _get_throughput(owner_name: str) -> float:
 def collect_trial_metrics(owner_name: str) -> dict[str, Any]:
     """Collect per-trial metrics for a node from the metrics module."""
     return {
-        "eg_failures": get_failures(owner_name),
-        "eg_success": get_successes(owner_name),
-        "eg_success_rate": get_success_rate(owner_name),
+        "eg_failures": get_eg_failures(owner_name),
+        "eg_success": get_eg_successes(owner_name),
+        "eg_success_rate": get_eg_success_rate(owner_name),
+        "ep_failures": get_ep_failures(owner_name),
+        "ep_success": get_ep_successes(owner_name),
+        "ep_success_rate": get_ep_success_rate(owner_name),
         "app_throughput": _get_throughput(owner_name),
         "event_records": storage.get_by_owner(owner_name),
     }

--- a/sequence/utils/metrics.py
+++ b/sequence/utils/metrics.py
@@ -1,0 +1,100 @@
+"""Centralized metrics tracking for SeQUeNCe simulations.
+
+This module provides a global registry for recording simulation events.
+Metrics are disabled by default; call ``enable()`` to opt in to recording.
+"""
+
+from __future__ import annotations
+
+from enum import Enum, auto
+from time import time_ns
+from typing import Any, Protocol
+
+
+class EventType(Enum):
+    """Event types that can be recorded by the metrics module."""
+
+    EG_ATTEMPT = auto()
+    EG_SUCCESS = auto()
+
+EG_ATTEMPT = EventType.EG_ATTEMPT
+EG_SUCCESS = EventType.EG_SUCCESS
+
+class TimeProvider(Protocol):
+    """Protocol for objects that supply a timestamp for recorded events."""
+
+    def now(self) -> int:
+        ...
+
+
+class SystemTimeProvider:
+    """Fallback time source using the current system clock."""
+
+    def now(self) -> int:
+        return time_ns()
+
+
+class InMemoryStorage:
+    """Store metric records in memory for the lifetime of the simulation."""
+
+    def __init__(self) -> None:
+        self._records: list[dict[str, Any]] = []
+
+    def append(self, record: dict[str, Any]) -> None:
+        self._records.append(record)
+
+    def get_all(self) -> list[dict[str, Any]]:
+        return list(self._records)
+
+    def get_by_event(self, event_type: EventType) -> list[dict[str, Any]]:
+        return [record for record in self._records if record["event_type"] is event_type]
+
+    def get_by_owner(self, owner_name: str) -> list[dict[str, Any]]:
+        return [record for record in self._records if record["owner_name"] == owner_name]
+
+    def clear(self) -> None:
+        self._records.clear()
+
+
+_enabled = False
+_enabled_events: set[EventType] = set()
+storage = InMemoryStorage()
+_system_time_provider = SystemTimeProvider()
+time_provider: TimeProvider = _system_time_provider
+
+
+def register_time_provider(provider: TimeProvider) -> None:
+    """Register the active time source for recorded events."""
+    global time_provider
+    time_provider = provider
+
+
+def enable(event_types: list[EventType]) -> None:
+    """Enable metrics recording for the given event types."""
+    global _enabled, _enabled_events
+    _enabled = True
+    _enabled_events = set(event_types)
+
+
+def configure(storage_type: str = "in_memory", time_provider: TimeProvider | None = None) -> None:
+    """Configure metrics storage and optional time source."""
+    global storage
+    if storage_type != "in_memory":
+        raise ValueError("Only in_memory storage is supported")
+
+    storage = InMemoryStorage()
+    if time_provider is not None:
+        register_time_provider(time_provider)
+
+
+def record(event_type: EventType, owner_name: str, **kwargs: Any) -> None:
+    """Record a metrics event if metrics are enabled for this event type."""
+    if not _enabled or event_type not in _enabled_events:
+        return
+
+    storage.append({
+        "event_type": event_type,
+        "owner_name": owner_name,
+        "sim_time": time_provider.now(),
+        **kwargs,
+    })

--- a/sequence/utils/metrics.py
+++ b/sequence/utils/metrics.py
@@ -14,17 +14,18 @@ from typing import Any, Protocol
 class EventType(Enum):
     """Event types that can be recorded by the metrics module."""
 
-    EG_ATTEMPT = auto()
+    EG_FAILURE = auto()
     EG_SUCCESS = auto()
 
-EG_ATTEMPT = EventType.EG_ATTEMPT
+
+EG_FAILURE = EventType.EG_FAILURE
 EG_SUCCESS = EventType.EG_SUCCESS
+
 
 class TimeProvider(Protocol):
     """Protocol for objects that supply a timestamp for recorded events."""
 
-    def now(self) -> int:
-        ...
+    def now(self) -> int: ...
 
 
 class SystemTimeProvider:
@@ -47,10 +48,14 @@ class InMemoryStorage:
         return list(self._records)
 
     def get_by_event(self, event_type: EventType) -> list[dict[str, Any]]:
-        return [record for record in self._records if record["event_type"] is event_type]
+        return [
+            record for record in self._records if record["event_type"] is event_type
+        ]
 
     def get_by_owner(self, owner_name: str) -> list[dict[str, Any]]:
-        return [record for record in self._records if record["owner_name"] == owner_name]
+        return [
+            record for record in self._records if record["owner_name"] == owner_name
+        ]
 
     def clear(self) -> None:
         self._records.clear()
@@ -62,6 +67,10 @@ storage = InMemoryStorage()
 _system_time_provider = SystemTimeProvider()
 time_provider: TimeProvider = _system_time_provider
 
+# Counter dicts that contain the failure and success counters for each node
+_failures: dict[str, int] = {}
+_successes: dict[str, int] = {}
+
 
 def register_time_provider(provider: TimeProvider) -> None:
     """Register the active time source for recorded events."""
@@ -69,32 +78,78 @@ def register_time_provider(provider: TimeProvider) -> None:
     time_provider = provider
 
 
+def reset_counters() -> None:
+    """Reset per-node attempt and success counters."""
+    _failures.clear()
+    _successes.clear()
+
+
+def get_failures(owner_name: str) -> int:
+    return _failures.get(owner_name, 0)
+
+
+def get_successes(owner_name: str) -> int:
+    return _successes.get(owner_name, 0)
+
+
+def get_success_rate(owner_name: str) -> float:
+    failures = get_failures(owner_name)
+    successes = get_successes(owner_name)
+    attempts = failures + successes
+    if attempts == 0:
+        return 0.0
+    return successes / attempts
+
+
 def enable(event_types: list[EventType]) -> None:
-    """Enable metrics recording for the given event types."""
+    """Enable metrics recording for the given event types.
+
+    Available metrics types are in the metrics.EventType enum.
+    """
     global _enabled, _enabled_events
     _enabled = True
     _enabled_events = set(event_types)
 
 
-def configure(storage_type: str = "in_memory", time_provider: TimeProvider | None = None) -> None:
-    """Configure metrics storage and optional time source."""
-    global storage
-    if storage_type != "in_memory":
-        raise ValueError("Only in_memory storage is supported")
+def configure(storage_type: str = "in_memory") -> None:
+    """Configure metrics storage
 
-    storage = InMemoryStorage()
-    if time_provider is not None:
-        register_time_provider(time_provider)
+    Available storage options:
+        - "in_memory": The default, uses `InMemoryStorage`. Keeps all records
+          available stored as a dictionary object in memory.
+    """
+    global storage
+    if storage_type == "in_memory":
+        storage = InMemoryStorage()
 
 
 def record(event_type: EventType, owner_name: str, **kwargs: Any) -> None:
-    """Record a metrics event if metrics are enabled for this event type."""
+    """Record a metrics event if metrics are enabled for this event type.
+
+    Will increment counter if counter is available for metric.
+    Metrics with counters:
+        - EG_SUCCESS
+        - EG_FAILURE
+
+    Will automatically record success rate for:
+        - EG_SUCCESS
+        - EG_FAILURE
+    """
     if not _enabled or event_type not in _enabled_events:
         return
 
-    storage.append({
-        "event_type": event_type,
-        "owner_name": owner_name,
-        "sim_time": time_provider.now(),
-        **kwargs,
-    })
+    if event_type is EG_FAILURE:
+        _failures[owner_name] = _failures.get(owner_name, 0) + 1
+        kwargs["success_rate"] = get_success_rate(owner_name)
+    elif event_type is EG_SUCCESS:
+        _successes[owner_name] = _successes.get(owner_name, 0) + 1
+        kwargs["success_rate"] = get_success_rate(owner_name)
+
+    storage.append(
+        {
+            "event_type": event_type,
+            "owner_name": owner_name,
+            "sim_time": time_provider.now(),
+            **kwargs,
+        }
+    )

--- a/sequence/utils/metrics.py
+++ b/sequence/utils/metrics.py
@@ -16,10 +16,12 @@ class EventType(Enum):
 
     EG_FAILURE = auto()
     EG_SUCCESS = auto()
+    THROUGHPUT = auto()
 
 
 EG_FAILURE = EventType.EG_FAILURE
 EG_SUCCESS = EventType.EG_SUCCESS
+THROUGHPUT = EventType.THROUGHPUT
 
 
 class TimeProvider(Protocol):
@@ -153,3 +155,16 @@ def record(event_type: EventType, owner_name: str, **kwargs: Any) -> None:
             **kwargs,
         }
     )
+
+
+def _get_throughput(owner_name: str) -> float:
+    throughput_records = [
+        record
+        for record in storage.get_by_owner(owner_name)
+        if record["event_type"] is THROUGHPUT
+    ]
+    if not throughput_records:
+        return float("nan")
+    return throughput_records[-1]["throughput"]
+
+

--- a/sequence/utils/metrics.py
+++ b/sequence/utils/metrics.py
@@ -6,6 +6,7 @@ Metrics are disabled by default; call ``enable()`` to opt in to recording.
 
 from __future__ import annotations
 
+import math
 from enum import Enum, auto
 from statistics import mean, stdev
 from time import time_ns
@@ -187,14 +188,23 @@ def aggregate_trial_metrics(trials: list[dict[str, Any]]) -> dict[str, float]:
 
     aggregated: dict[str, float] = {}
     scalar_metrics = [
-        key
-        for key, value in trials[0].items()
-        if not isinstance(value, (list, dict))
+        key for key, value in trials[0].items() if not isinstance(value, (list, dict))
     ]
 
     for metric in scalar_metrics:
         values = [trial[metric] for trial in trials]
-        aggregated[f"avg_{metric}"] = mean(values)
-        aggregated[f"std_{metric}"] = stdev(values) if len(values) > 1 else 0.0
+        finite_values = [
+            value
+            for value in values
+            if isinstance(value, (int, float)) and math.isfinite(value)
+        ]
+        if finite_values:
+            aggregated[f"avg_{metric}"] = mean(finite_values)
+            aggregated[f"std_{metric}"] = (
+                stdev(finite_values) if len(finite_values) > 1 else 0.0
+            )
+        else:
+            aggregated[f"avg_{metric}"] = float("nan")
+            aggregated[f"std_{metric}"] = float("nan")
 
     return aggregated

--- a/sequence/utils/metrics.py
+++ b/sequence/utils/metrics.py
@@ -7,6 +7,7 @@ Metrics are disabled by default; call ``enable()`` to opt in to recording.
 from __future__ import annotations
 
 from enum import Enum, auto
+from statistics import mean, stdev
 from time import time_ns
 from typing import Any, Protocol
 
@@ -168,3 +169,32 @@ def _get_throughput(owner_name: str) -> float:
     return throughput_records[-1]["throughput"]
 
 
+def collect_trial_metrics(owner_name: str) -> dict[str, Any]:
+    """Collect per-trial metrics for a node from the metrics module."""
+    return {
+        "eg_failures": get_failures(owner_name),
+        "eg_success": get_successes(owner_name),
+        "eg_success_rate": get_success_rate(owner_name),
+        "app_throughput": _get_throughput(owner_name),
+        "event_records": storage.get_by_owner(owner_name),
+    }
+
+
+def aggregate_trial_metrics(trials: list[dict[str, Any]]) -> dict[str, float]:
+    """Aggregate scalar trial metrics across multiple trials."""
+    if not trials:
+        raise ValueError("Cannot aggregate an empty list of trials")
+
+    aggregated: dict[str, float] = {}
+    scalar_metrics = [
+        key
+        for key, value in trials[0].items()
+        if not isinstance(value, (list, dict))
+    ]
+
+    for metric in scalar_metrics:
+        values = [trial[metric] for trial in trials]
+        aggregated[f"avg_{metric}"] = mean(values)
+        aggregated[f"std_{metric}"] = stdev(values) if len(values) > 1 else 0.0
+
+    return aggregated

--- a/sequence/utils/metrics.py
+++ b/sequence/utils/metrics.py
@@ -6,7 +6,9 @@ Metrics are disabled by default; call ``enable()`` to opt in to recording.
 
 from __future__ import annotations
 
+import json
 import math
+import time
 from enum import Enum, auto
 from statistics import mean, stdev
 from time import time_ns
@@ -21,6 +23,7 @@ class EventType(Enum):
     THROUGHPUT = auto()
     EP_FAILURE = auto()
     EP_SUCCESS = auto()
+    PURIFIED_DELIVERY = auto()
 
 
 EG_FAILURE = EventType.EG_FAILURE
@@ -28,6 +31,7 @@ EG_SUCCESS = EventType.EG_SUCCESS
 THROUGHPUT = EventType.THROUGHPUT
 EP_FAILURE = EventType.EP_FAILURE
 EP_SUCCESS = EventType.EP_SUCCESS
+PURIFIED_DELIVERY = EventType.PURIFIED_DELIVERY
 
 
 class TimeProvider(Protocol):
@@ -200,23 +204,65 @@ def _get_throughput(owner_name: str) -> float:
     return throughput_records[-1]["throughput"]
 
 
-# Not super generalized but works in the MVP
-def collect_trial_metrics(owner_name: str) -> dict[str, Any]:
+def _get_purified_fidelities(owner_name: str) -> list[float]:
+    return [
+        record["fidelity"]
+        for record in storage.get_by_owner(owner_name)
+        if record["event_type"] is EP_SUCCESS and "fidelity" in record
+    ]
+
+
+def _get_app_ep_time(
+    delivery_owner: str,
+    target_pairs: int,
+    reservation_start_time: int | None,
+) -> float:
+    delivery_records = [
+        record
+        for record in storage.get_by_owner(delivery_owner)
+        if record["event_type"] is PURIFIED_DELIVERY
+    ]
+    delivery_records.sort(key=lambda record: record["sim_time"])
+    if len(delivery_records) < target_pairs:
+        return float("nan")
+    if reservation_start_time is None:
+        return float("nan")
+    target_time = delivery_records[target_pairs - 1]["sim_time"]
+    return (target_time - reservation_start_time) * 1e-12
+
+
+def collect_trial_metrics(
+    owner_name: str,
+    *,
+    delivery_owner: str | None = None,
+    target_pairs: int = 500,
+    reservation_start_time: int | None = None,
+) -> dict[str, Any]:
     """Collect per-trial metrics for a node from the metrics module."""
-    return {
+    delivery_owner = delivery_owner or owner_name
+    result = {
         "eg_failures": get_eg_failures(owner_name),
         "eg_success": get_eg_successes(owner_name),
         "eg_success_rate": get_eg_success_rate(owner_name),
         "ep_failures": get_ep_failures(owner_name),
         "ep_success": get_ep_successes(owner_name),
         "ep_success_rate": get_ep_success_rate(owner_name),
+        "purified_fidelities": _get_purified_fidelities(owner_name),
         "app_throughput": _get_throughput(owner_name),
+        "app_ep_time": _get_app_ep_time(
+            delivery_owner, target_pairs, reservation_start_time
+        ),
         "event_records": storage.get_by_owner(owner_name),
     }
+    return result
 
 
-def aggregate_trial_metrics(trials: list[dict[str, Any]]) -> dict[str, float]:
-    """Aggregate scalar trial metrics across multiple trials."""
+def aggregate_trial_metrics(
+    trials: list[dict[str, Any]],
+    *,
+    list_metric_cap: int | None = 500,
+) -> dict[str, float]:
+    """Aggregate trial metrics across multiple trials."""
     if not trials:
         raise ValueError("Cannot aggregate an empty list of trials")
 
@@ -224,6 +270,7 @@ def aggregate_trial_metrics(trials: list[dict[str, Any]]) -> dict[str, float]:
     scalar_metrics = [
         key for key, value in trials[0].items() if not isinstance(value, (list, dict))
     ]
+    list_metrics = [key for key, value in trials[0].items() if isinstance(value, list)]
 
     for metric in scalar_metrics:
         values = [trial[metric] for trial in trials]
@@ -236,6 +283,24 @@ def aggregate_trial_metrics(trials: list[dict[str, Any]]) -> dict[str, float]:
             aggregated[f"avg_{metric}"] = mean(finite_values)
             aggregated[f"std_{metric}"] = (
                 stdev(finite_values) if len(finite_values) > 1 else 0.0
+            )
+        else:
+            aggregated[f"avg_{metric}"] = float("nan")
+            aggregated[f"std_{metric}"] = float("nan")
+
+    for metric in list_metrics:
+        if metric == "event_records":
+            continue
+        all_values: list[float] = []
+        for trial in trials:
+            trial_values = trial[metric]
+            if list_metric_cap is not None:
+                trial_values = trial_values[:list_metric_cap]
+            all_values.extend(trial_values)
+        if all_values:
+            aggregated[f"avg_{metric}"] = mean(all_values)
+            aggregated[f"std_{metric}"] = (
+                stdev(all_values) if len(all_values) > 1 else 0.0
             )
         else:
             aggregated[f"avg_{metric}"] = float("nan")

--- a/sequence/utils/metrics.py
+++ b/sequence/utils/metrics.py
@@ -71,15 +71,19 @@ storage = InMemoryStorage()
 _system_time_provider = SystemTimeProvider()
 time_provider: TimeProvider = _system_time_provider
 
-# Counter dicts that contain the failure and success counters for each node
-_failures: dict[str, int] = {}
-_successes: dict[str, int] = {}
-
 
 def register_time_provider(provider: TimeProvider) -> None:
     """Register the active time source for recorded events."""
     global time_provider
     time_provider = provider
+
+
+# TODO: Hopefully the counters and the 4 functions associated with them
+# can be generalized for purification and swapping as well
+
+# Counter dicts that contain the failure and success counters for each node
+_failures: dict[str, int] = {}
+_successes: dict[str, int] = {}
 
 
 def reset_counters() -> None:
@@ -170,6 +174,7 @@ def _get_throughput(owner_name: str) -> float:
     return throughput_records[-1]["throughput"]
 
 
+# Not super generalized but works in the MVP
 def collect_trial_metrics(owner_name: str) -> dict[str, Any]:
     """Collect per-trial metrics for a node from the metrics module."""
     return {

--- a/tests/utils/test_metrics.py
+++ b/tests/utils/test_metrics.py
@@ -216,6 +216,20 @@ def test_aggregate_trial_metrics_empty_list_raises():
         metrics.aggregate_trial_metrics([])
 
 
+def test_aggregate_trial_metrics_ignores_non_finite_values():
+    trials = [
+        {"eg_success_rate": 0.5, "app_throughput": float("nan")},
+        {"eg_success_rate": 0.6, "app_throughput": 2.0},
+        {"eg_success_rate": 0.4, "app_throughput": 4.0},
+    ]
+
+    aggregated = metrics.aggregate_trial_metrics(trials)
+
+    assert aggregated["avg_eg_success_rate"] == pytest.approx(0.5)
+    assert aggregated["avg_app_throughput"] == 3.0
+    assert aggregated["std_app_throughput"] == pytest.approx(1.4142135623730951)
+
+
 def test_request_app_record_throughput_metric():
     tl = Timeline()
     node = QuantumRouter("router_0", tl)
@@ -229,3 +243,27 @@ def test_request_app_record_throughput_metric():
 
     trial = metrics.collect_trial_metrics("router_0")
     assert trial["app_throughput"] == pytest.approx(10.0)
+
+
+def test_request_app_schedules_throughput_on_responder_only():
+    from sequence.network_management.reservation import Reservation
+
+    tl = Timeline(stop_time=int(3e12))
+    responder = QuantumRouter("right", tl)
+    initiator = QuantumRouter("left", tl)
+    responder_app = RequestApp(responder)
+    RequestApp(initiator)
+
+    reservation = Reservation(
+        "left", "right", int(1e12), int(2e12), 2, 0.9,
+    )
+    metrics.enable([metrics.THROUGHPUT])
+    responder_app.memory_counter = 4
+    responder_app.schedule_reservation(reservation)
+
+    tl.init()
+    tl.run()
+
+    trial = metrics.collect_trial_metrics("right")
+    assert trial["app_throughput"] == pytest.approx(4.0)
+    assert math.isnan(metrics.collect_trial_metrics("left")["app_throughput"])

--- a/tests/utils/test_metrics.py
+++ b/tests/utils/test_metrics.py
@@ -8,6 +8,7 @@ def reset_metrics():
     metrics._enabled = False
     metrics._enabled_events.clear()
     metrics.storage.clear()
+    metrics.reset_counters()
     metrics.register_time_provider(metrics._system_time_provider)
 
 
@@ -20,7 +21,7 @@ def test_record_before_enable_is_noop():
 def test_enable_filters_event_types():
     metrics.enable([metrics.EG_SUCCESS])
 
-    metrics.record(metrics.EG_ATTEMPT, "e0", round=1)
+    metrics.record(metrics.EG_FAILURE, "e0", initial_fidelity=0.9)
     metrics.record(metrics.EG_SUCCESS, "e0", fidelity=0.9)
 
     records = metrics.storage.get_all()
@@ -31,25 +32,81 @@ def test_enable_filters_event_types():
 
 
 def test_record_stores_arbitrary_kwargs():
-    metrics.enable([metrics.EG_ATTEMPT])
+    metrics.enable([metrics.EG_FAILURE])
 
-    metrics.record(metrics.EG_ATTEMPT, "e1", round=2, custom_metric=42)
+    metrics.record(metrics.EG_FAILURE, "e1", initial_fidelity=0.8, custom_metric=42)
 
     record = metrics.storage.get_all()[0]
-    assert record["round"] == 2
+    assert record["initial_fidelity"] == 0.8
     assert record["custom_metric"] == 42
 
 
-def test_configure_uses_in_memory_storage():
-    metrics.enable([metrics.EG_SUCCESS])
-    metrics.record(metrics.EG_SUCCESS, "e0", fidelity=0.8)
-    assert len(metrics.storage.get_all()) == 1
+def test_configure_replaces_storage():
+    metrics.enable([metrics.EG_FAILURE, metrics.EG_SUCCESS])
+    metrics.record(metrics.EG_FAILURE, "e0")
+    metrics.record(metrics.EG_SUCCESS, "e0")
+    assert len(metrics.storage.get_all()) == 2
 
     metrics.configure(storage_type="in_memory")
+
     assert metrics.storage.get_all() == []
 
 
-# In case a timeline is never created (rare but could happen?)
+def test_reset_counters_clears_per_node_counts():
+    metrics.enable([metrics.EG_FAILURE, metrics.EG_SUCCESS])
+    metrics.record(metrics.EG_FAILURE, "e0")
+    metrics.record(metrics.EG_SUCCESS, "e0")
+
+    metrics.reset_counters()
+
+    assert metrics.get_failures("e0") == 0
+    assert metrics.get_successes("e0") == 0
+    assert metrics.get_success_rate("e0") == 0.0
+
+
+def test_per_node_counters_are_independent():
+    metrics.enable([metrics.EG_FAILURE, metrics.EG_SUCCESS])
+
+    metrics.record(metrics.EG_FAILURE, "e0")
+    metrics.record(metrics.EG_FAILURE, "e0")
+    metrics.record(metrics.EG_SUCCESS, "e0")
+    metrics.record(metrics.EG_FAILURE, "e1")
+
+    assert metrics.get_failures("e0") == 2
+    assert metrics.get_successes("e0") == 1
+    assert metrics.get_success_rate("e0") == pytest.approx(1 / 3)
+    assert metrics.get_failures("e1") == 1
+    assert metrics.get_successes("e1") == 0
+    assert metrics.get_success_rate("e1") == 0.0
+
+
+def test_completion_events_record_running_success_rate():
+    metrics.enable([metrics.EG_FAILURE, metrics.EG_SUCCESS])
+
+    metrics.record(metrics.EG_FAILURE, "e0")
+    metrics.record(metrics.EG_SUCCESS, "e0")
+    metrics.record(metrics.EG_FAILURE, "e0")
+
+    failure_records = metrics.storage.get_by_event(metrics.EG_FAILURE)
+    success_records = metrics.storage.get_by_event(metrics.EG_SUCCESS)
+
+    assert failure_records[0]["success_rate"] == 0.0
+    assert success_records[0]["success_rate"] == 0.5
+    assert failure_records[1]["success_rate"] == pytest.approx(1 / 3)
+
+
+def test_storage_query_helpers():
+    metrics.enable([metrics.EG_FAILURE, metrics.EG_SUCCESS])
+
+    metrics.record(metrics.EG_FAILURE, "e0", initial_fidelity=0.9)
+    metrics.record(metrics.EG_SUCCESS, "e0", fidelity=0.9)
+    metrics.record(metrics.EG_FAILURE, "e1", initial_fidelity=0.9)
+
+    assert len(metrics.storage.get_by_event(metrics.EG_FAILURE)) == 2
+    assert len(metrics.storage.get_by_owner("e0")) == 2
+    assert len(metrics.storage.get_by_owner("e1")) == 1
+
+
 def test_default_time_provider_uses_system_time(monkeypatch):
     monkeypatch.setattr(metrics._system_time_provider, "now", lambda: 42)
     metrics.register_time_provider(metrics._system_time_provider)
@@ -71,15 +128,3 @@ def test_register_time_provider_uses_registered_source():
     metrics.record(metrics.EG_SUCCESS, "e0", fidelity=0.9)
 
     assert metrics.storage.get_all()[0]["sim_time"] == 12345
-
-
-def test_storage_query_helpers():
-    metrics.enable([metrics.EG_ATTEMPT, metrics.EG_SUCCESS])
-
-    metrics.record(metrics.EG_ATTEMPT, "e0", round=1)
-    metrics.record(metrics.EG_SUCCESS, "e0", fidelity=0.9)
-    metrics.record(metrics.EG_ATTEMPT, "e1", round=1)
-
-    assert len(metrics.storage.get_by_event(metrics.EG_ATTEMPT)) == 2
-    assert len(metrics.storage.get_by_owner("e0")) == 2
-    assert len(metrics.storage.get_by_owner("e1")) == 1

--- a/tests/utils/test_metrics.py
+++ b/tests/utils/test_metrics.py
@@ -1,0 +1,85 @@
+import pytest
+
+from sequence.utils import metrics
+
+
+@pytest.fixture(autouse=True)
+def reset_metrics():
+    metrics._enabled = False
+    metrics._enabled_events.clear()
+    metrics.storage.clear()
+    metrics.register_time_provider(metrics._system_time_provider)
+
+
+# Tests that record doesn't do anything if the user has not enabled metrics
+def test_record_before_enable_is_noop():
+    metrics.record(metrics.EG_SUCCESS, "e0", fidelity=0.9)
+    assert metrics.storage.get_all() == []
+
+
+def test_enable_filters_event_types():
+    metrics.enable([metrics.EG_SUCCESS])
+
+    metrics.record(metrics.EG_ATTEMPT, "e0", round=1)
+    metrics.record(metrics.EG_SUCCESS, "e0", fidelity=0.9)
+
+    records = metrics.storage.get_all()
+    assert len(records) == 1
+    assert records[0]["event_type"] is metrics.EG_SUCCESS
+    assert records[0]["owner_name"] == "e0"
+    assert records[0]["fidelity"] == 0.9
+
+
+def test_record_stores_arbitrary_kwargs():
+    metrics.enable([metrics.EG_ATTEMPT])
+
+    metrics.record(metrics.EG_ATTEMPT, "e1", round=2, custom_metric=42)
+
+    record = metrics.storage.get_all()[0]
+    assert record["round"] == 2
+    assert record["custom_metric"] == 42
+
+
+def test_configure_uses_in_memory_storage():
+    metrics.enable([metrics.EG_SUCCESS])
+    metrics.record(metrics.EG_SUCCESS, "e0", fidelity=0.8)
+    assert len(metrics.storage.get_all()) == 1
+
+    metrics.configure(storage_type="in_memory")
+    assert metrics.storage.get_all() == []
+
+
+# In case a timeline is never created (rare but could happen?)
+def test_default_time_provider_uses_system_time(monkeypatch):
+    monkeypatch.setattr(metrics._system_time_provider, "now", lambda: 42)
+    metrics.register_time_provider(metrics._system_time_provider)
+    metrics.enable([metrics.EG_SUCCESS])
+
+    metrics.record(metrics.EG_SUCCESS, "e0", fidelity=0.9)
+
+    assert metrics.storage.get_all()[0]["sim_time"] == 42
+
+
+def test_register_time_provider_uses_registered_source():
+    class StubTimeProvider:
+        def now(self) -> int:
+            return 12345
+
+    metrics.register_time_provider(StubTimeProvider())
+    metrics.enable([metrics.EG_SUCCESS])
+
+    metrics.record(metrics.EG_SUCCESS, "e0", fidelity=0.9)
+
+    assert metrics.storage.get_all()[0]["sim_time"] == 12345
+
+
+def test_storage_query_helpers():
+    metrics.enable([metrics.EG_ATTEMPT, metrics.EG_SUCCESS])
+
+    metrics.record(metrics.EG_ATTEMPT, "e0", round=1)
+    metrics.record(metrics.EG_SUCCESS, "e0", fidelity=0.9)
+    metrics.record(metrics.EG_ATTEMPT, "e1", round=1)
+
+    assert len(metrics.storage.get_by_event(metrics.EG_ATTEMPT)) == 2
+    assert len(metrics.storage.get_by_owner("e0")) == 2
+    assert len(metrics.storage.get_by_owner("e1")) == 1

--- a/tests/utils/test_metrics.py
+++ b/tests/utils/test_metrics.py
@@ -1,5 +1,10 @@
+import math
+
 import pytest
 
+from sequence.app.request_app import RequestApp
+from sequence.kernel.timeline import Timeline
+from sequence.topology.node import QuantumRouter
 from sequence.utils import metrics
 
 
@@ -128,3 +133,99 @@ def test_register_time_provider_uses_registered_source():
     metrics.record(metrics.EG_SUCCESS, "e0", fidelity=0.9)
 
     assert metrics.storage.get_all()[0]["sim_time"] == 12345
+
+
+def test_throughput_does_not_affect_eg_counters():
+    metrics.enable([metrics.EG_FAILURE, metrics.EG_SUCCESS, metrics.THROUGHPUT])
+
+    metrics.record(metrics.EG_FAILURE, "e0")
+    metrics.record(metrics.EG_SUCCESS, "e0")
+    metrics.record(metrics.THROUGHPUT, "e0", throughput=42.0)
+
+    assert metrics.get_failures("e0") == 1
+    assert metrics.get_successes("e0") == 1
+    assert metrics.get_success_rate("e0") == 0.5
+
+
+def test_collect_trial_metrics_returns_node_snapshot():
+    metrics.enable([metrics.EG_FAILURE, metrics.EG_SUCCESS, metrics.THROUGHPUT])
+
+    metrics.record(metrics.EG_FAILURE, "e0", initial_fidelity=0.8)
+    metrics.record(metrics.EG_SUCCESS, "e0", fidelity=0.8)
+    metrics.record(metrics.THROUGHPUT, "e0", throughput=12.5)
+
+    trial = metrics.collect_trial_metrics("e0")
+
+    assert trial["eg_failures"] == 1
+    assert trial["eg_success"] == 1
+    assert trial["eg_success_rate"] == 0.5
+    assert trial["app_throughput"] == 12.5
+    assert len(trial["event_records"]) == 3
+
+
+def test_collect_trial_metrics_without_throughput_is_nan():
+    metrics.enable([metrics.EG_SUCCESS])
+    metrics.record(metrics.EG_SUCCESS, "e0", fidelity=0.9)
+
+    trial = metrics.collect_trial_metrics("e0")
+
+    assert math.isnan(trial["app_throughput"])
+
+
+def test_aggregate_trial_metrics_computes_avg_and_std():
+    trials = [
+        {"eg_failures": 10, "eg_success": 5, "eg_success_rate": 0.5, "app_throughput": 1.0},
+        {"eg_failures": 12, "eg_success": 6, "eg_success_rate": 0.5, "app_throughput": 2.0},
+    ]
+
+    aggregated = metrics.aggregate_trial_metrics(trials)
+
+    assert aggregated["avg_eg_failures"] == 11
+    assert aggregated["avg_eg_success"] == 5.5
+    assert aggregated["avg_app_throughput"] == 1.5
+    assert aggregated["std_eg_failures"] == pytest.approx(1.4142135623730951)
+
+
+def test_aggregate_trial_metrics_single_trial_has_zero_std():
+    trials = [{"eg_failures": 3, "eg_success": 1, "eg_success_rate": 0.25, "app_throughput": 4.0}]
+
+    aggregated = metrics.aggregate_trial_metrics(trials)
+
+    assert aggregated["avg_eg_failures"] == 3
+    assert aggregated["std_eg_failures"] == 0.0
+
+
+def test_aggregate_trial_metrics_skips_event_records():
+    trials = [
+        {
+            "eg_failures": 1,
+            "eg_success": 1,
+            "eg_success_rate": 0.5,
+            "app_throughput": 1.0,
+            "event_records": [{"event_type": metrics.EG_SUCCESS}],
+        }
+    ]
+
+    aggregated = metrics.aggregate_trial_metrics(trials)
+
+    assert "avg_event_records" not in aggregated
+
+
+def test_aggregate_trial_metrics_empty_list_raises():
+    with pytest.raises(ValueError, match="empty list"):
+        metrics.aggregate_trial_metrics([])
+
+
+def test_request_app_record_throughput_metric():
+    tl = Timeline()
+    node = QuantumRouter("router_0", tl)
+    app = RequestApp(node)
+    app.start_t = int(1e12)
+    app.end_t = int(2e12)
+    app.memory_counter = 10
+
+    metrics.enable([metrics.THROUGHPUT])
+    app.record_throughput_metric()
+
+    trial = metrics.collect_trial_metrics("router_0")
+    assert trial["app_throughput"] == pytest.approx(10.0)

--- a/tests/utils/test_metrics.py
+++ b/tests/utils/test_metrics.py
@@ -58,15 +58,20 @@ def test_configure_replaces_storage():
 
 
 def test_reset_counters_clears_per_node_counts():
-    metrics.enable([metrics.EG_FAILURE, metrics.EG_SUCCESS])
+    metrics.enable([metrics.EG_FAILURE, metrics.EG_SUCCESS, metrics.EP_FAILURE, metrics.EP_SUCCESS])
     metrics.record(metrics.EG_FAILURE, "e0")
     metrics.record(metrics.EG_SUCCESS, "e0")
+    metrics.record(metrics.EP_FAILURE, "e0")
+    metrics.record(metrics.EP_SUCCESS, "e0")
 
     metrics.reset_counters()
 
-    assert metrics.get_failures("e0") == 0
-    assert metrics.get_successes("e0") == 0
-    assert metrics.get_success_rate("e0") == 0.0
+    assert metrics.get_eg_failures("e0") == 0
+    assert metrics.get_eg_successes("e0") == 0
+    assert metrics.get_eg_success_rate("e0") == 0.0
+    assert metrics.get_ep_failures("e0") == 0
+    assert metrics.get_ep_successes("e0") == 0
+    assert metrics.get_ep_success_rate("e0") == 0.0
 
 
 def test_per_node_counters_are_independent():
@@ -77,12 +82,12 @@ def test_per_node_counters_are_independent():
     metrics.record(metrics.EG_SUCCESS, "e0")
     metrics.record(metrics.EG_FAILURE, "e1")
 
-    assert metrics.get_failures("e0") == 2
-    assert metrics.get_successes("e0") == 1
-    assert metrics.get_success_rate("e0") == pytest.approx(1 / 3)
-    assert metrics.get_failures("e1") == 1
-    assert metrics.get_successes("e1") == 0
-    assert metrics.get_success_rate("e1") == 0.0
+    assert metrics.get_eg_failures("e0") == 2
+    assert metrics.get_eg_successes("e0") == 1
+    assert metrics.get_eg_success_rate("e0") == pytest.approx(1 / 3)
+    assert metrics.get_eg_failures("e1") == 1
+    assert metrics.get_eg_successes("e1") == 0
+    assert metrics.get_eg_success_rate("e1") == 0.0
 
 
 def test_completion_events_record_running_success_rate():
@@ -142,9 +147,9 @@ def test_throughput_does_not_affect_eg_counters():
     metrics.record(metrics.EG_SUCCESS, "e0")
     metrics.record(metrics.THROUGHPUT, "e0", throughput=42.0)
 
-    assert metrics.get_failures("e0") == 1
-    assert metrics.get_successes("e0") == 1
-    assert metrics.get_success_rate("e0") == 0.5
+    assert metrics.get_eg_failures("e0") == 1
+    assert metrics.get_eg_successes("e0") == 1
+    assert metrics.get_eg_success_rate("e0") == 0.5
 
 
 def test_collect_trial_metrics_returns_node_snapshot():

--- a/tests/utils/test_metrics.py
+++ b/tests/utils/test_metrics.py
@@ -272,3 +272,125 @@ def test_request_app_schedules_throughput_on_responder_only():
     trial = metrics.collect_trial_metrics("right")
     assert trial["app_throughput"] == pytest.approx(4.0)
     assert math.isnan(metrics.collect_trial_metrics("left")["app_throughput"])
+
+
+def test_ep_counters_and_success_rate():
+    metrics.enable([metrics.EP_FAILURE, metrics.EP_SUCCESS])
+
+    metrics.record(metrics.EP_FAILURE, "left")
+    metrics.record(metrics.EP_SUCCESS, "left", fidelity=0.75)
+    metrics.record(metrics.EP_FAILURE, "left")
+
+    assert metrics.get_ep_failures("left") == 2
+    assert metrics.get_ep_successes("left") == 1
+    assert metrics.get_ep_success_rate("left") == pytest.approx(1 / 3)
+
+    success_records = metrics.storage.get_by_event(metrics.EP_SUCCESS)
+    assert success_records[0]["ep_success_rate"] == pytest.approx(0.5)
+
+
+def test_purified_delivery_does_not_affect_ep_counters():
+    metrics.enable([metrics.EP_FAILURE, metrics.EP_SUCCESS, metrics.PURIFIED_DELIVERY])
+
+    metrics.record(metrics.EP_SUCCESS, "left", fidelity=0.8)
+    metrics.record(metrics.PURIFIED_DELIVERY, "right", fidelity=0.8, pair_number=1)
+
+    assert metrics.get_ep_successes("left") == 1
+    assert metrics.get_ep_failures("right") == 0
+
+
+def test_collect_trial_metrics_ep_fields_and_delivery_time():
+    class StubTimeProvider:
+        def __init__(self) -> None:
+            self._time = int(1e12)
+
+        def now(self) -> int:
+            current = self._time
+            self._time += int(1e11)
+            return current
+
+    provider = StubTimeProvider()
+    metrics.register_time_provider(provider)
+    metrics.enable([metrics.EP_SUCCESS, metrics.PURIFIED_DELIVERY])
+
+    metrics.record(metrics.EP_SUCCESS, "left", fidelity=0.7)
+    metrics.record(metrics.EP_SUCCESS, "left", fidelity=0.75)
+
+    for pair_number in range(1, 4):
+        metrics.record(
+            metrics.PURIFIED_DELIVERY,
+            "right",
+            fidelity=0.7 + pair_number * 0.01,
+            pair_number=pair_number,
+        )
+
+    trial = metrics.collect_trial_metrics(
+        "left",
+        delivery_owner="right",
+        target_pairs=3,
+        reservation_start_time=int(1e12),
+    )
+
+    assert trial["ep_success"] == 2
+    assert trial["purified_fidelities"] == [0.7, 0.75]
+    assert trial["app_ep_time"] == pytest.approx(0.4)
+
+
+def test_collect_trial_metrics_app_ep_time_nan_when_target_not_reached():
+    metrics.enable([metrics.PURIFIED_DELIVERY])
+    metrics.record(metrics.PURIFIED_DELIVERY, "right", fidelity=0.9, pair_number=1)
+
+    trial = metrics.collect_trial_metrics(
+        "left",
+        delivery_owner="right",
+        target_pairs=500,
+        reservation_start_time=int(1e12),
+    )
+
+    assert math.isnan(trial["app_ep_time"])
+
+
+def test_collect_trial_metrics_delivery_owner_defaults_to_owner():
+    metrics.enable([metrics.PURIFIED_DELIVERY])
+    metrics.record(metrics.PURIFIED_DELIVERY, "right", fidelity=0.9, pair_number=1)
+
+    trial = metrics.collect_trial_metrics(
+        "right",
+        target_pairs=1,
+        reservation_start_time=0,
+    )
+
+    assert not math.isnan(trial["app_ep_time"])
+
+
+def test_aggregate_trial_metrics_flattens_purified_fidelities():
+    trials = [
+        {
+            "ep_success_rate": 0.6,
+            "purified_fidelities": [0.7, 0.75],
+            "app_ep_time": 10.0,
+        },
+        {
+            "ep_success_rate": 0.7,
+            "purified_fidelities": [0.8],
+            "app_ep_time": 9.0,
+        },
+    ]
+
+    aggregated = metrics.aggregate_trial_metrics(trials)
+
+    assert aggregated["avg_purified_fidelities"] == pytest.approx(0.75)
+    assert aggregated["std_purified_fidelities"] == pytest.approx(0.05)
+    assert aggregated["avg_app_ep_time"] == 9.5
+
+
+def test_aggregate_trial_metrics_handles_nan_app_ep_time():
+    trials = [
+        {"app_ep_time": float("nan"), "purified_fidelities": [0.7]},
+        {"app_ep_time": 12.0, "purified_fidelities": [0.8]},
+    ]
+
+    aggregated = metrics.aggregate_trial_metrics(trials)
+
+    assert aggregated["avg_app_ep_time"] == 12.0
+    assert aggregated["std_app_ep_time"] == 0.0


### PR DESCRIPTION
This PR implements a MVP of #368. The current supported event types are `EG_SUCCESS`, `EG_FAILURE`, and `THROUGHPUT`. 

`SingleHeraldedA` was edited to include an override of the `_entanglement_fail()` method that records entanglement failures, and the `_entanglement_succeed()` now records entanglement successes. The `entanglement_fail()` can be moved into the super class later, but I did not want to touch it yet as the MVP only provides protocol support for `SingleHeraldedA`. 

`RequestApp` was edited to include a record event for the app's throughput. It was also edited to provide helpful support against NaN values appearing, although this was mainly due to an error I kept getting when attempting to implement `THROUGHPUT` using the metrics module. This may be a necessary bug fix, or it may be overengineering a little.

`Timeline` includes a single line that registers itself as the global metrics time provider when it is created. This is necessary for metrics to know when events occurred in simulation time. If no timeline is created (which shouldn't happen) then it default to the system time.

Test methods for all of the metrics methods in different situations are implemented in `test_metrics.py`. 

An edited version of [this entanglement generation experiment](https://github.com/sequence-toolbox/entanglement_purification_experiment/blob/6c49f649bdacfeebefcd85c91e9902151d775368/eg_symmetric_experiment.py) has been implemented using the metrics module instead of monkey patching, and produces two graphs - one comparing success rate to simulation time, and another comparing success rate to initial fidelity. They are both effectively constant at y = 0.076, which is what we wanted.