### PR TITLE
docs: clarify that memories arg is intentionally unused in swapping set_others (refs #170)

### DIFF
--- a/sequence/entanglement_management/swapping/swapping_base.py
+++ b/sequence/entanglement_management/swapping/swapping_base.py
@@ -196,15 +196,16 @@ class EntanglementSwappingA(EntanglementProtocol, ABC):
     def set_others(self, protocol: str, node: str, memories: list[str]) -> None:
         """Method to set other entanglement protocol instance.
 
+        Note:
+            ``memories`` is intentionally unused here (swapping keys off the
+            left/right memos it already holds); it is kept to match the shared
+            EntanglementProtocol.set_others() interface. See issue #170.
+
         Args:
             protocol (str): other protocol name.
             node (str): other node name.
             memories (list[str]): the list of memories name used on other node.
         """
-        # `memories` is intentionally unused here: the swapping protocol keys off the
-        # left/right memos it already holds. It is kept to match the shared
-        # EntanglementProtocol.set_others() interface (ResourceManager calls it
-        # positionally, and the generation protocols do use it). See issue #170.
         if node == self.left_memo.entangled_memory["node_id"]:
             self.left_protocol_name = protocol
         elif node == self.right_memo.entangled_memory["node_id"]:

--- a/sequence/entanglement_management/swapping/swapping_base.py
+++ b/sequence/entanglement_management/swapping/swapping_base.py
@@ -201,6 +201,10 @@ class EntanglementSwappingA(EntanglementProtocol, ABC):
             node (str): other node name.
             memories (list[str]): the list of memories name used on other node.
         """
+        # `memories` is intentionally unused here: the swapping protocol keys off the
+        # left/right memos it already holds. It is kept to match the shared
+        # EntanglementProtocol.set_others() interface (ResourceManager calls it
+        # positionally, and the generation protocols do use it). See issue #170.
         if node == self.left_memo.entangled_memory["node_id"]:
             self.left_protocol_name = protocol
         elif node == self.right_memo.entangled_memory["node_id"]:
@@ -359,6 +363,8 @@ class EntanglementSwappingB(EntanglementProtocol, ABC):
             node (str): other node name.
             memories (list[str]): the list of memory names used on other node.
         """
+        # `memories` is intentionally unused here (as in EntanglementSwappingA): kept to
+        # match the shared EntanglementProtocol.set_others() interface. See issue #170.
         self.remote_node_name = node
         self.remote_protocol_name = protocol
 

--- a/sequence/entanglement_management/swapping/swapping_base.py
+++ b/sequence/entanglement_management/swapping/swapping_base.py
@@ -198,7 +198,7 @@ class EntanglementSwappingA(EntanglementProtocol, ABC):
 
         Note:
             ``memories`` is intentionally unused; swapping uses the memos it
-            already holds. Kept for interface compatibility (see issue #170).
+            already holds. Kept for interface compatibility.
 
         Args:
             protocol (str): other protocol name.
@@ -360,7 +360,7 @@ class EntanglementSwappingB(EntanglementProtocol, ABC):
 
         Note:
             ``memories`` is intentionally unused; swapping uses the memos it
-            already holds. Kept for interface compatibility (see issue #170).
+            already holds. Kept for interface compatibility.
 
         Args:
             protocol (str): other protocol name.

--- a/sequence/entanglement_management/swapping/swapping_base.py
+++ b/sequence/entanglement_management/swapping/swapping_base.py
@@ -197,9 +197,8 @@ class EntanglementSwappingA(EntanglementProtocol, ABC):
         """Method to set other entanglement protocol instance.
 
         Note:
-            ``memories`` is intentionally unused here (swapping keys off the
-            left/right memos it already holds); it is kept to match the shared
-            EntanglementProtocol.set_others() interface. See issue #170.
+            ``memories`` is intentionally unused; swapping uses the memos it
+            already holds. Kept for interface compatibility (see issue #170).
 
         Args:
             protocol (str): other protocol name.
@@ -359,13 +358,15 @@ class EntanglementSwappingB(EntanglementProtocol, ABC):
     def set_others(self, protocol: str, node: str, memories: list[str]) -> None:
         """Method to set other entanglement protocol instance.
 
+        Note:
+            ``memories`` is intentionally unused; swapping uses the memos it
+            already holds. Kept for interface compatibility (see issue #170).
+
         Args:
             protocol (str): other protocol name.
             node (str): other node name.
             memories (list[str]): the list of memory names used on other node.
         """
-        # `memories` is intentionally unused here (as in EntanglementSwappingA): kept to
-        # match the shared EntanglementProtocol.set_others() interface. See issue #170.
         self.remote_node_name = node
         self.remote_protocol_name = protocol
 


### PR DESCRIPTION
Follow-up to #170.

`EntanglementSwappingA.set_others` (and, as noted in #170's thread, `EntanglementSwappingB.set_others`) accept a `memories` argument that they never use — the swapping protocols key off the `left_memo`/`right_memo` they already hold.

The argument cannot simply be removed, though: `set_others(remote_protocol, remote_node, memories)` is the shared `EntanglementProtocol` interface, called **positionally** by `ResourceManager` (`resource_manager.py:410` and `:439`) on any protocol instance, and the generation protocols do use it (`self.remote_memo_id = memories[0]`). Dropping it from the swapping overrides would raise a `TypeError` when the manager pairs a swapping protocol.

This PR just adds a short clarifying comment in both swapping `set_others` overrides explaining the argument is intentionally unused there and kept for interface consistency. No behavior change.