### PR TITLE
ci: Ignore dependabot branches in gitlab mirror

### DIFF
--- a/.github/workflows/mirror_gitlab.yml
+++ b/.github/workflows/mirror_gitlab.yml
@@ -1,7 +1,7 @@
 name: Mirror to GitLab
 on:
   push:
-    branches: [ '**' ]
+    branches-ignore: [ 'dependabot/**' ]
     tags: [ '**' ]
   delete:
   workflow_dispatch:
@@ -15,8 +15,9 @@ concurrency:
 
 jobs:
   mirror:
-    if: github.repository == 'sequence-toolbox/SeQUeNCe'
+    if: github.repository == 'sequence-toolbox/SeQUeNCe' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout full history
         uses: actions/checkout@v7

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -1,6 +1,6 @@
 name: Validate PRs
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, edited]
 
 permissions:


### PR DESCRIPTION
ci: validate_pr title running with wrong permissions on forks