### PR TITLE
ci: run validate-pr-title on pull_request_target so it works for fork PRs

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -1,6 +1,6 @@
 name: Validate PRs
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, edited]
 
 permissions:


### PR DESCRIPTION
Fixes #393.

Fork PRs receive a read-only \`GITHUB_TOKEN\`, so the label-writing step of \`ytanikin/pr-conventional-commits\` fails with \`Resource not accessible by integration\` for every external contributor — the required check goes red regardless of the (valid) title.

Following @hayekr's suggestion in #393, this switches the trigger from \`pull_request\` to \`pull_request_target\`, so the workflow runs with the base repository's token and can apply the label. The job only reads the PR title from the event payload and does not check out or execute PR code, so `pull_request_target` is safe here.

Note: this PR is itself a fork PR, so its own \`validate-pr-title\` run will still hit the old behavior until this is merged.