### PR TITLE
ci: normalize PyPI publish labels

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to PyPi
+name: Publish to PyPI
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-release:
-    name: Build the release
+    name: Build the PyPI release
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.repository == 'sequence-toolbox/SeQUeNCe'
     steps:
@@ -21,14 +21,14 @@ jobs:
           enable-cache: true
       - name: Build wheel and tarball
         run: uv build
-      - name: Store dist as an artifact
+      - name: Store PyPI dist as an artifact
         uses: actions/upload-artifact@v7
         with:
           name: python-release-package-dist
           path: dist/
 
   build-test-release:
-    name: Build the test release
+    name: Build the TestPyPI release
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.repository == 'sequence-toolbox/SeQUeNCe'
     steps:
@@ -42,16 +42,16 @@ jobs:
       - name: Modify package name for TestPyPI
         run: |
           sed -i 's/^name = "sequence"/name = "ssequence"/' pyproject.toml
-      - name: Build wheel and tarball for test
+      - name: Build TestPyPI wheel and tarball
         run: uv build
-      - name: Store test dist as an artifact
+      - name: Store TestPyPI dist as an artifact
         uses: actions/upload-artifact@v7
         with:
           name: python-test-package-dist
           path: dist/
 
   publish-to-pypi:
-    name: Publish dist to PyPi
+    name: Publish dist to PyPI
     if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'sequence-toolbox/SeQUeNCe'
     needs:
       - build-release
@@ -63,18 +63,18 @@ jobs:
       id-token: write
 
     steps:
-      - name: Download all the dists
+      - name: Download PyPI dist
         uses: actions/download-artifact@v8
         with:
           name: python-release-package-dist
           path: dist/
-      - name: Publish dist to TestPyPI
+      - name: Publish dist to PyPI
         uses: pypa/gh-action-pypi-publish@v1.14.0
         with:
           attestations: true
 
   publish-to-test-pypi:
-    name: Publish dist to TestPyPi
+    name: Publish dist to TestPyPI
     if: github.event_name == 'push' && github.repository == 'sequence-toolbox/SeQUeNCe'
     needs:
       - build-test-release
@@ -87,7 +87,7 @@ jobs:
       id-token: write
 
     steps:
-      - name: Download all the test dists
+      - name: Download TestPyPI dist
         uses: actions/download-artifact@v8
         with:
           name: python-test-package-dist

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <div align="center">
 
-[![PyPi](https://img.shields.io/pypi/v/sequence)](https://pypi.org/project/sequence/)
+[![PyPI](https://img.shields.io/pypi/v/sequence)](https://pypi.org/project/sequence/)
 ![pyversions](https://img.shields.io/pypi/pyversions/sequence)
 [![CI Pipeline](https://github.com/sequence-toolbox/SeQUeNCe/actions/workflows/ci.yml/badge.svg)](https://github.com/sequence-toolbox/SeQUeNCe/actions/workflows/ci.yml)
 [![Documentation](https://img.shields.io/readthedocs/sequence-rtd-tutorial)](https://sequence-rtd-tutorial.readthedocs.io/)


### PR DESCRIPTION
## Summary

Normalizes visible PyPI/TestPyPI labels in the publishing workflow and README badge.

## Changes

- Normalize PyPI capitalization in workflow and README labels.
- Clarify production PyPI build, artifact, download, and publish labels.
- Clarify TestPyPI build, artifact, download, and publish labels.
- Correct the production publish step label so it no longer says `TestPyPI`.
- Keep workflow triggers, permissions, artifact names, environments, and publishing behavior unchanged.

## Tests

- `git diff --check HEAD~1..HEAD`

## Intentionally Excluded

- No workflow trigger changes.
- No permission changes.
- No package publishing behavior changes.
- No dependency or lockfile changes.