### PR TITLE
ci: update dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,13 +3,36 @@ updates:
   - package-ecosystem: "uv" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "weekly"
     commit-message:
       prefix: "chore"
+    cooldown:
+      default-days: 7
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "chore"
+    cooldown:
+      default-days: 7
+    groups:
+      major-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/mirror_gitlab.yml
+++ b/.github/workflows/mirror_gitlab.yml
@@ -11,7 +11,7 @@ permissions:
 
 concurrency:
   group: mirror-to-gitlab
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   mirror:


### PR DESCRIPTION
Adds cooldown, extends schedule, and adds grouping to dependabot PRs. Fix concurrency issue with gitlab mirror