### PR TITLE
feat: Change ruff line length for formatting to 120 chars

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,3 +131,5 @@ default_bump_level = 0
 parse_squash_commits = true
 ignore_merge_commits = true
 
+[tool.ruff]
+line-length = 120


### PR DESCRIPTION
Changes line length for the ruff formatter to 120 chars in the `pyproject.toml` file