### PR TITLE
fix: guard draw_topo CLI behind a main() entry point

### DIFF
--- a/sequence/utils/draw_topo.py
+++ b/sequence/utils/draw_topo.py
@@ -11,71 +11,94 @@ from graphviz import Graph
 from json import load
 from collections import defaultdict
 
+from sequence.topology.topology import Topology
 from sequence.topology.router_net_topo import RouterNetTopo
 from sequence.topology.qkd_topo import QKDTopo
 from sequence.topology.dqc_net_topo import DQCNetTopo
 
 
-parser = argparse.ArgumentParser()
-parser.add_argument('config_file', help="path to json file defining network")
-parser.add_argument('-d', '--directory', type=str, default='tmp', help='directory to save the figure')
-parser.add_argument('-f', '--filename', type=str, default='topology', help='filename of the figure')
-parser.add_argument('-m', '--draw_middle', action='store_true')
+def get_topology(config_file: str) -> Topology:
+    """
+    Determine the type of network described by a config file and load it.
+    Args:
+        config_file: path to json file defining network
 
-args = parser.parse_args()
-directory = args.directory
-filename = args.filename
-draw_middle = args.draw_middle
+    Returns: The topology matching the type of the config file's first node
+    """
+    with open(config_file, 'r') as fh:
+        config = load(fh)
+    nodes = config["nodes"]
+    node_type = nodes[0]["type"]
 
-# Determine type of network
-with open(args.config_file, 'r') as fh:
-    config = load(fh)
-nodes = config["nodes"]
-node_type = nodes[0]["type"]
+    if node_type == RouterNetTopo.BSM_NODE or node_type == RouterNetTopo.QUANTUM_ROUTER:
+        return RouterNetTopo(config_file)
 
-if node_type == RouterNetTopo.BSM_NODE or node_type == RouterNetTopo.QUANTUM_ROUTER:
-    topo = RouterNetTopo(args.config_file)
+    elif node_type == QKDTopo.QKD_NODE:
+        return QKDTopo(config_file)
 
-elif node_type == QKDTopo.QKD_NODE:
-    topo = QKDTopo(args.config_file)
+    elif node_type == DQCNetTopo.DQC_NODE:
+        return DQCNetTopo(config_file)
 
-elif node_type == DQCNetTopo.DQC_NODE:
-    topo = DQCNetTopo(args.config_file)
-
-else:
-    raise Exception("Unknown node type '{}' in config file {}".format(node_type, args.config_file))
-
-# make graph
-g = Graph(format='png')
-g.attr(layout='neato', overlap='false')
-
-# add nodes and translate qchannels from graph
-node_types = list(topo.nodes.keys())
-
-for node_type in node_types:
-    if node_type == RouterNetTopo.BSM_NODE:
-        if draw_middle:
-            for node in topo.get_nodes_by_type(node_type):
-                g.node(node.name, label='BSM', shape='rectangle')
     else:
-        for node in topo.get_nodes_by_type(node_type):
-            g.node(node.name)
-
-if draw_middle:
-    # draw the middle BSM node
-    for qchannel in topo.get_qchannels():
-        g.edge(qchannel.sender.name, qchannel.receiver, color='blue', dir='forward')
-else:
-    # do not draw the middle BSM node
-    bsm_to_node = defaultdict(list)
-    for qchannel in topo.get_qchannels():
-        node = qchannel.sender.name
-        bsm = qchannel.receiver
-        bsm_to_node[bsm].append(node)
-    qconnections = set()
-    for bsm, nodes in bsm_to_node.items():
-        assert len(nodes) == 2, f'{bsm} connects to {len(nodes)} number of nodes (should be 2)'
-        g.edge(nodes[0], nodes[1], color='blue')
+        raise Exception("Unknown node type '{}' in config file {}".format(node_type, config_file))
 
 
-g.view(directory=directory, filename=filename)
+def draw_topology(topo: Topology, draw_middle: bool = False) -> Graph:
+    """
+    Build the graph of a topology's nodes and quantum channels.
+    Args:
+        topo: the topology to draw
+        draw_middle: draw the middle BSM nodes, default is False
+
+    Returns: The graph of the topology
+    """
+    g = Graph(format='png')
+    g.attr(layout='neato', overlap='false')
+
+    # add nodes and translate qchannels from graph
+    node_types = list(topo.nodes.keys())
+
+    for node_type in node_types:
+        if node_type == RouterNetTopo.BSM_NODE:
+            if draw_middle:
+                for node in topo.get_nodes_by_type(node_type):
+                    g.node(node.name, label='BSM', shape='rectangle')
+        else:
+            for node in topo.get_nodes_by_type(node_type):
+                g.node(node.name)
+
+    if draw_middle:
+        # draw the middle BSM node
+        for qchannel in topo.get_qchannels():
+            g.edge(qchannel.sender.name, qchannel.receiver, color='blue', dir='forward')
+    else:
+        # do not draw the middle BSM node
+        bsm_to_node = defaultdict(list)
+        for qchannel in topo.get_qchannels():
+            node = qchannel.sender.name
+            bsm = qchannel.receiver
+            bsm_to_node[bsm].append(node)
+        for bsm, nodes in bsm_to_node.items():
+            assert len(nodes) == 2, f'{bsm} connects to {len(nodes)} number of nodes (should be 2)'
+            g.edge(nodes[0], nodes[1], color='blue')
+
+    return g
+
+
+def main() -> None:
+    """Draw the network of a json config file and open the resulting figure."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument('config_file', help="path to json file defining network")
+    parser.add_argument('-d', '--directory', type=str, default='tmp', help='directory to save the figure')
+    parser.add_argument('-f', '--filename', type=str, default='topology', help='filename of the figure')
+    parser.add_argument('-m', '--draw_middle', action='store_true')
+
+    args = parser.parse_args()
+
+    topo = get_topology(args.config_file)
+    g = draw_topology(topo, args.draw_middle)
+    g.view(directory=args.directory, filename=args.filename)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/utils/test_draw_topo.py
+++ b/tests/utils/test_draw_topo.py
@@ -1,0 +1,64 @@
+import subprocess
+import sys
+
+import pytest
+
+from sequence.topology.dqc_net_topo import DQCNetTopo
+from sequence.topology.qkd_topo import QKDTopo
+from sequence.topology.router_net_topo import RouterNetTopo
+from sequence.utils.draw_topo import draw_topology, get_topology
+
+ROUTER_CONFIG = "tests/topology/router_net_topo_sample_config.json"
+QKD_CONFIG = "tests/topology/qkd_net_topo_sample_config.json"
+DQC_CONFIG = "tests/topology/dqc_node_net_topo_simple.json"
+
+
+def test_import_does_not_run_cli():
+    """Importing the module must not parse arguments, read files, or draw."""
+    result = subprocess.run([sys.executable, "-c", "import sequence.utils.draw_topo"],
+                            capture_output=True, text=True, check=False)
+    assert result.returncode == 0, result.stderr
+    assert result.stderr == ""
+
+
+def test_get_topology_router_net():
+    assert isinstance(get_topology(ROUTER_CONFIG), RouterNetTopo)
+
+
+def test_get_topology_qkd():
+    assert isinstance(get_topology(QKD_CONFIG), QKDTopo)
+
+
+def test_get_topology_dqc_net():
+    assert isinstance(get_topology(DQC_CONFIG), DQCNetTopo)
+
+
+def test_get_topology_unknown_node_type(tmp_path):
+    config_file = tmp_path / "unknown_net_topo.json"
+    config_file.write_text('{"nodes": [{"name": "node_0", "type": "UnknownNode"}]}')
+
+    with pytest.raises(Exception, match="Unknown node type 'UnknownNode'"):
+        get_topology(str(config_file))
+
+
+def test_draw_topology_without_middle():
+    """The routers are joined directly, the BSM nodes between them are left out."""
+    source = draw_topology(get_topology(ROUTER_CONFIG)).source
+
+    for router in ("router_0", "router_1", "router_2"):
+        assert router in source
+    assert "BSM_router_0_router_1" not in source
+    assert "BSM_router_1_router_2" not in source
+    assert "router_0 -- router_1" in source
+    assert "router_1 -- router_2" in source
+
+
+def test_draw_topology_with_middle():
+    """The BSM nodes are drawn, with one edge per quantum channel."""
+    source = draw_topology(get_topology(ROUTER_CONFIG), draw_middle=True).source
+
+    assert "BSM_router_0_router_1 [label=BSM shape=rectangle]" in source
+    assert "BSM_router_1_router_2 [label=BSM shape=rectangle]" in source
+    assert source.count(" -- ") == 4
+    assert "router_0 -- BSM_router_0_router_1" in source
+    assert "router_2 -- BSM_router_1_router_2" in source


### PR DESCRIPTION
This PR proposes guarding the `sequence/utils/draw_topo.py` command line interface behind a `main()` entry point, so that importing the module no longer exits the interpreter (Fixes #436). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/207. You can sign in with your GitHub ID to claim ownership of the project.

## What is wrong

`sequence/utils/draw_topo.py` calls `parser.parse_args()` at module scope, together with the rest of the command line body: reading the config file, constructing the topology and building the graph all happen as a side effect of importing the module. Because `argparse` exits when the required `config_file` argument is absent, importing the module raises `SystemExit` before a caller can do anything with it. On `master` at `09cfb67`:

```console
$ python -c "import sequence.utils.draw_topo"
usage: -c [-h] [-d DIRECTORY] [-f FILENAME] [-m] config_file
-c: error: the following arguments are required: config_file
$ echo $?
2
```

The consequence reaches a little further than the reference page described in #436. Since the module terminates the interpreter that imports it, `pytest` cannot collect a test module that imports it either — the whole run aborts during collection with `INTERNALERROR ... SystemExit: 2` instead of reporting a failure, which is why this module has no tests today. `docs/scripts/generate_reference_rst.py` generates a `misc/utils` reference section from every module in `sequence/utils`, so autodoc imports this one as well.

## The change

The module body is split into three functions with no behaviour change: `get_topology()` resolves a config file to the matching `RouterNetTopo`, `QKDTopo` or `DQCNetTopo`, `draw_topology()` builds the graphviz graph, and `main()` does the argument parsing and rendering. `main()` runs only under `if __name__ == "__main__"`, so `python -m sequence.utils.draw_topo` and `python sequence/utils/draw_topo.py` keep working exactly as before, with the same flags and the same output, while `import sequence.utils.draw_topo` is now free of side effects. Splitting the drawing out of the command line body is also what makes the module testable, and it lets the graph be built programmatically, which #436 asks for.

## How this was verified

The full suite was run on a clean checkout before the change and after it: 407 tests pass on unmodified `master` and 414 pass with this change applied, with nothing moving from passing to failing. The seven new tests in `tests/utils/test_draw_topo.py` cover the side-effect-free import, the topology dispatch for each supported config type, the unknown node type path, and both the default and `--draw_middle` drawing branches; against the unmodified module they cannot even be collected, failing with the `SystemExit` above. The command line itself was exercised end to end against `tests/topology/router_net_topo_sample_config.json`, and the graph it emits is unchanged:

```
graph {
	layout=neato overlap=false
	router_0
	router_1
	router_2
	router_0 -- router_1 [color=blue]
	router_1 -- router_2 [color=blue]
}
```

`ruff check` reports the same findings on `sequence/utils/draw_topo.py` as it does on `master`, and none on the new test module.

## How this was managed

We imported your issues and pull requests into a live agile board and used it to track this work: the story for #436 is at https://eastagiletracker.com/projects/207/stories/75053, on the board at https://eastagiletracker.com/projects/207 (425 stories and 18 labels imported from this repository).

![board](https://raw.githubusercontent.com/eastagiletracker/SeQUeNCe/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
