### PR TITLE
 refactor: guard draw_topo.py CLI behind main() so the module imports cleanly

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Editable installations let Python use your local source tree directly, so change
 #### (1) Using pip
 ```
 git clone https://github.com/sequence-toolbox/SeQUeNCe.git
-cd sequence
+cd SeQUeNCe
 make install_editable
 ```
 
@@ -80,7 +80,7 @@ powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | ie
 Here we clone the repository and let uv configure the development environment with the target python version.
 ```bash
 git clone https://github.com/sequence-toolbox/SeQUeNCe.git
-cd sequence
+cd SeQUeNCe
 uv sync
 ```
 

--- a/sequence/utils/draw_topo.py
+++ b/sequence/utils/draw_topo.py
@@ -73,7 +73,6 @@ def main() -> None:
             node = qchannel.sender.name
             bsm = qchannel.receiver
             bsm_to_node[bsm].append(node)
-        qconnections = set()
         for bsm, nodes in bsm_to_node.items():
             assert len(nodes) == 2, f'{bsm} connects to {len(nodes)} number of nodes (should be 2)'
             g.edge(nodes[0], nodes[1], color='blue')

--- a/sequence/utils/draw_topo.py
+++ b/sequence/utils/draw_topo.py
@@ -16,66 +16,70 @@ from sequence.topology.qkd_topo import QKDTopo
 from sequence.topology.dqc_net_topo import DQCNetTopo
 
 
-parser = argparse.ArgumentParser()
-parser.add_argument('config_file', help="path to json file defining network")
-parser.add_argument('-d', '--directory', type=str, default='tmp', help='directory to save the figure')
-parser.add_argument('-f', '--filename', type=str, default='topology', help='filename of the figure')
-parser.add_argument('-m', '--draw_middle', action='store_true')
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('config_file', help="path to json file defining network")
+    parser.add_argument('-d', '--directory', type=str, default='tmp', help='directory to save the figure')
+    parser.add_argument('-f', '--filename', type=str, default='topology', help='filename of the figure')
+    parser.add_argument('-m', '--draw_middle', action='store_true')
 
-args = parser.parse_args()
-directory = args.directory
-filename = args.filename
-draw_middle = args.draw_middle
+    args = parser.parse_args()
+    directory = args.directory
+    filename = args.filename
+    draw_middle = args.draw_middle
 
-# Determine type of network
-with open(args.config_file, 'r') as fh:
-    config = load(fh)
-nodes = config["nodes"]
-node_type = nodes[0]["type"]
+    # Determine type of network
+    with open(args.config_file, 'r') as fh:
+        config = load(fh)
+    nodes = config["nodes"]
+    node_type = nodes[0]["type"]
 
-if node_type == RouterNetTopo.BSM_NODE or node_type == RouterNetTopo.QUANTUM_ROUTER:
-    topo = RouterNetTopo(args.config_file)
+    if node_type == RouterNetTopo.BSM_NODE or node_type == RouterNetTopo.QUANTUM_ROUTER:
+        topo = RouterNetTopo(args.config_file)
 
-elif node_type == QKDTopo.QKD_NODE:
-    topo = QKDTopo(args.config_file)
+    elif node_type == QKDTopo.QKD_NODE:
+        topo = QKDTopo(args.config_file)
 
-elif node_type == DQCNetTopo.DQC_NODE:
-    topo = DQCNetTopo(args.config_file)
+    elif node_type == DQCNetTopo.DQC_NODE:
+        topo = DQCNetTopo(args.config_file)
 
-else:
-    raise Exception("Unknown node type '{}' in config file {}".format(node_type, args.config_file))
-
-# make graph
-g = Graph(format='png')
-g.attr(layout='neato', overlap='false')
-
-# add nodes and translate qchannels from graph
-node_types = list(topo.nodes.keys())
-
-for node_type in node_types:
-    if node_type == RouterNetTopo.BSM_NODE:
-        if draw_middle:
-            for node in topo.get_nodes_by_type(node_type):
-                g.node(node.name, label='BSM', shape='rectangle')
     else:
-        for node in topo.get_nodes_by_type(node_type):
-            g.node(node.name)
+        raise Exception("Unknown node type '{}' in config file {}".format(node_type, args.config_file))
 
-if draw_middle:
-    # draw the middle BSM node
-    for qchannel in topo.get_qchannels():
-        g.edge(qchannel.sender.name, qchannel.receiver, color='blue', dir='forward')
-else:
-    # do not draw the middle BSM node
-    bsm_to_node = defaultdict(list)
-    for qchannel in topo.get_qchannels():
-        node = qchannel.sender.name
-        bsm = qchannel.receiver
-        bsm_to_node[bsm].append(node)
-    qconnections = set()
-    for bsm, nodes in bsm_to_node.items():
-        assert len(nodes) == 2, f'{bsm} connects to {len(nodes)} number of nodes (should be 2)'
-        g.edge(nodes[0], nodes[1], color='blue')
+    # make graph
+    g = Graph(format='png')
+    g.attr(layout='neato', overlap='false')
+
+    # add nodes and translate qchannels from graph
+    node_types = list(topo.nodes.keys())
+
+    for node_type in node_types:
+        if node_type == RouterNetTopo.BSM_NODE:
+            if draw_middle:
+                for node in topo.get_nodes_by_type(node_type):
+                    g.node(node.name, label='BSM', shape='rectangle')
+        else:
+            for node in topo.get_nodes_by_type(node_type):
+                g.node(node.name)
+
+    if draw_middle:
+        # draw the middle BSM node
+        for qchannel in topo.get_qchannels():
+            g.edge(qchannel.sender.name, qchannel.receiver, color='blue', dir='forward')
+    else:
+        # do not draw the middle BSM node
+        bsm_to_node = defaultdict(list)
+        for qchannel in topo.get_qchannels():
+            node = qchannel.sender.name
+            bsm = qchannel.receiver
+            bsm_to_node[bsm].append(node)
+        qconnections = set()
+        for bsm, nodes in bsm_to_node.items():
+            assert len(nodes) == 2, f'{bsm} connects to {len(nodes)} number of nodes (should be 2)'
+            g.edge(nodes[0], nodes[1], color='blue')
+
+    g.view(directory=directory, filename=filename)
 
 
-g.view(directory=directory, filename=filename)
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Recreate PR #444 & #445 because they are blocked by CodeQL for unknown reasons. I temporarily unchecked "Require code scanning results" in the branch ruleset. Then recreate PR #444 and #445

NOTE: "Require code scanning results" is unchecked, but GitHub CodeQL still automatically runs by default.