### PR TITLE
feat: add new module utils.classical_delay

### DIFF
--- a/sequence/utils/classical_delay.py
+++ b/sequence/utils/classical_delay.py
@@ -1,0 +1,81 @@
+"""
+Classical delay utility functions.
+"""
+
+from networkx import Graph, single_source_dijkstra, exception
+from sequence.topology.router_net_topo import RouterNetTopo
+from sequence.constants import SPEED_OF_LIGHT, MILLISECOND
+
+
+def classical_delay(distance: float, hop_count: int, classical_delay_node: float, classical_delay_hop: float) -> int:
+    """Model the classical delay as a function of distance and hop count
+
+    Args:
+        distance (float): the distance between source and destination in km
+        hop_count (int): the number of hops/nodes between source and destination
+        classical_delay_node (float): delay at the destination node in milliseconds
+        classical_delay_hop (float): delay for each intermediate hop in milliseconds
+    
+    Returns:
+        int: the delay in picoseconds
+    """
+    return int(distance / SPEED_OF_LIGHT + (hop_count * classical_delay_hop + classical_delay_node) * MILLISECOND)
+
+
+def update_cchannel_delay(topo: RouterNetTopo, classical_delay_node: float, classical_delay_hop: float) -> None:
+    """Update the delay of classical channels based on the network topology and classical delay model.
+
+    Args:
+        topo (RouterNetTopo): the topology of the network
+        classical_delay_node (float): delay at the destination node in milliseconds
+        classical_delay_hop (float): delay for each intermediate hop in milliseconds
+    """
+    nodes = [node.name for node in topo.nodes[topo.QUANTUM_ROUTER]]
+    graph = Graph()
+    for node in nodes:
+        graph.add_node(node)
+
+    all_paths = {}  # (src, dst) -> (length: float, hop: int, path: tuple)
+    costs = {}      # the cost of each edge in the graph, used for Dijkstra's algorithm
+    # process the classical channels within a link: node -- BSM -- node
+    for qc in topo.qchannels:
+        router = qc.sender.name
+        bsm = qc.receiver
+        router, bsm = qc.sender.name, qc.receiver
+        all_paths[(router, bsm)] = (qc.distance, 0, (router, bsm))
+        all_paths[(bsm, router)] = (qc.distance, 0, (bsm, router))
+
+        if bsm not in costs:
+            costs[bsm] = [router, qc.distance]
+        else:
+            costs[bsm] = [router] + costs[bsm]
+            costs[bsm][-1] += qc.distance
+
+    # process the classical channels between nodes: node -- node
+    graph.add_weighted_edges_from(costs.values())
+    for src in nodes:
+        for dst in nodes:
+            if src == dst:
+                continue
+            try:
+                if dst > src:
+                    length, path = single_source_dijkstra(graph, src, dst)
+                else:
+                    length, path = single_source_dijkstra(graph, dst, src)
+                    path = path[::-1]
+                hop_count = len(path) - 2
+                all_paths[(src, dst)] = (length, hop_count, tuple(path))
+            except exception.NetworkXNoPath:
+                all_paths[(src, dst)] = (float('inf'), 0, ())
+
+    # update the classical channel delay
+    for cc in topo.cchannels:
+        src = cc.sender.name
+        dst = cc.receiver
+        length, hop_count, path = all_paths[(src, dst)]
+        if length == float('inf'):
+            cc.delay = topo.get_timeline().stop_time + 1
+            cc.distance = float('inf')
+        else:
+            cc.delay = classical_delay(length, hop_count, classical_delay_node, classical_delay_hop)
+            cc.distance = length

--- a/sequence/utils/classical_delay.py
+++ b/sequence/utils/classical_delay.py
@@ -4,7 +4,7 @@ Classical delay utility functions.
 
 from networkx import Graph, single_source_dijkstra, exception
 from sequence.topology.router_net_topo import RouterNetTopo
-from sequence.constants import SPEED_OF_LIGHT, MILLISECOND
+from sequence.constants import SPEED_OF_LIGHT, MICROSECOND
 
 
 def classical_delay(distance: float, hop_count: int, classical_delay_node: float, classical_delay_hop: float) -> int:
@@ -13,13 +13,13 @@ def classical_delay(distance: float, hop_count: int, classical_delay_node: float
     Args:
         distance (float): the distance between source and destination in km
         hop_count (int): the number of hops/nodes between source and destination
-        classical_delay_node (float): delay at the destination node in milliseconds
-        classical_delay_hop (float): delay for each intermediate hop in milliseconds
+        classical_delay_node (float): delay at the destination node in microseconds
+        classical_delay_hop (float): delay for each intermediate hop in microseconds
     
     Returns:
         int: the delay in picoseconds
     """
-    return int(distance / SPEED_OF_LIGHT + (hop_count * classical_delay_hop + classical_delay_node) * MILLISECOND)
+    return int(distance / SPEED_OF_LIGHT + (hop_count * classical_delay_hop + classical_delay_node) * MICROSECOND)
 
 
 def update_cchannel_delay(topo: RouterNetTopo, classical_delay_node: float, classical_delay_hop: float) -> None:
@@ -27,8 +27,8 @@ def update_cchannel_delay(topo: RouterNetTopo, classical_delay_node: float, clas
 
     Args:
         topo (RouterNetTopo): the topology of the network
-        classical_delay_node (float): delay at the destination node in milliseconds
-        classical_delay_hop (float): delay for each intermediate hop in milliseconds
+        classical_delay_node (float): delay at the destination node in microseconds
+        classical_delay_hop (float): delay for each intermediate hop in microseconds
     """
     nodes = [node.name for node in topo.nodes[topo.QUANTUM_ROUTER]]
     graph = Graph()

--- a/sequence/utils/classical_delay.py
+++ b/sequence/utils/classical_delay.py
@@ -41,7 +41,6 @@ def update_cchannel_delay(topo: RouterNetTopo, classical_delay_node: float, clas
     for qc in topo.qchannels:
         router = qc.sender.name
         bsm = qc.receiver
-        router, bsm = qc.sender.name, qc.receiver
         all_paths[(router, bsm)] = (qc.distance, 0, (router, bsm))
         all_paths[(bsm, router)] = (qc.distance, 0, (bsm, router))
 

--- a/sequence/utils/nx_converter.py
+++ b/sequence/utils/nx_converter.py
@@ -180,10 +180,10 @@ def generate_config(g: nx.Graph, cc_delay: float, memory_size: int=5, output_fil
     if formalism:
         output_dict[Topology.FORMALISM] = formalism
 
-    output_dir = Path(output_directory)
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    with open(output_dir / output_file, 'w') as f:
-        json.dump(output_dict, f, indent=2)
+    if output_directory and output_file:
+        output_dir = Path(output_directory)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        with open(output_dir / output_file, 'w') as f:
+            json.dump(output_dict, f, indent=2)
 
     return output_dict, graph_to_name

--- a/tests/utils/test_classical_delay.py
+++ b/tests/utils/test_classical_delay.py
@@ -1,0 +1,29 @@
+from sequence.utils.classical_delay import update_cchannel_delay
+from sequence.utils.config_generator_cli import generate_config, build_linear
+from sequence.topology.router_net_topo import RouterNetTopo
+from sequence.constants import MICROSECOND, MILLISECOND
+
+
+def test_update_cchannel_delay():
+    # linear topology: 0 -- 1 -- 2
+    g = build_linear(3, length=10.0, attenuation=0.0002)
+    config, graph_to_name = generate_config(g, cc_delay=1, output_file=None, output_directory=None)
+    topo = RouterNetTopo(config)
+    r0 = graph_to_name[0]
+    r1 = graph_to_name[1]
+    r2 = graph_to_name[2]
+    cc_01_name = f"cc-{r0}-{r1}"
+    cc_02_name = f"cc-{r0}-{r2}"
+    cc_12_name = f"cc-{r1}-{r2}"
+    cc_01 = topo.tl.get_entity_by_name(cc_01_name)
+    cc_02 = topo.tl.get_entity_by_name(cc_02_name)
+    cc_12 = topo.tl.get_entity_by_name(cc_12_name)
+
+    # before update: every classical channel has a delay of 1 millisecond
+    assert cc_01.delay == cc_02.delay == cc_12.delay == 1 * MILLISECOND
+
+    update_cchannel_delay(topo, classical_delay_node=100, classical_delay_hop=20)
+
+    # after update: the classical channel delay varies based on the distance and hop count
+    assert cc_01.delay == cc_12.delay == 150 * MICROSECOND # 50 + 100
+    assert cc_02.delay == 220 * MICROSECOND # 100 + 20 + 100


### PR DESCRIPTION
Added a new module `utils.classical_delay`.

The current delay for the classical delay is set to a constant value across all router pairs. See https://github.com/sequence-toolbox/SeQUeNCe/blob/1f3583c53c4b14e16a01549731b352b57ae9ebe0/sequence/utils/nx_converter.py#L66

This new module calculates the shortest path between two nodes in the network and sets the classical delay between the two nodes using a classical delay model.

I frequently do this in my projects. Now it is time to bring this piece of code into the codebase.