### PR TITLE
ci: finalize generated changelog format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,19 +115,28 @@ variable_start_string = "{{"
 variable_end_string = "}}"
 comment_start_string = "{#"
 comment_end_string = "#}"
-trim_blocks = false
-lstrip_blocks = false
+trim_blocks = true
+lstrip_blocks = true
 newline_sequence = "\n"
-keep_trailing_newline = false
+keep_trailing_newline = true
 extensions = []
 autoescape = false
 
 [tool.semantic_release.commit_parser_options]
 minor_tags = ["feat"]
-patch_tags = ["fix", "perf"]
-other_allowed_tags = ["build", "chore", "ci", "docs", "style", "refactor", "test"]
-allowed_tags = ["feat", "fix", "perf", "build", "chore", "ci", "docs", "style", "refactor", "test"]
+patch_tags = [
+    "fix",
+    "docs",
+    "test",
+    "ci",
+    "refactor",
+    "perf",
+    "chore",
+    "revert",
+]
+allowed_tags = ["feat", "fix", "perf", "build", "ci", "docs", "style", "refactor", "test"]
+other_allowed_tags = ["chore"]
+
 default_bump_level = 0
 parse_squash_commits = true
 ignore_merge_commits = true
-

--- a/uv.lock
+++ b/uv.lock
@@ -1683,7 +1683,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [


### PR DESCRIPTION
This PR finalizes the changelog format that PSR generates. It also ignores the PR's tagged `chore:` as they are mainly used by dependabot and are "noisy"